### PR TITLE
Linux fixes

### DIFF
--- a/gl/gloffscreen.h
+++ b/gl/gloffscreen.h
@@ -38,6 +38,7 @@
 #include <GL/gl.h>
 #include <GL/glext.h>
 #else
+#include <GL/glew.h>
 #include <GL/gl.h>
 #endif
 

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1388,7 +1388,7 @@ static uint64_t fnv_hash(const uint8_t *data, size_t len)
 
 static uint64_t fast_hash(const uint8_t *data, size_t len, unsigned int samples)
 {
-// #ifdef __SSE4_2__
+#ifdef __SSE4_2__
     uint64_t h[4] = {len, 0, 0, 0};
     assert(samples > 0);
 
@@ -1417,9 +1417,9 @@ static uint64_t fast_hash(const uint8_t *data, size_t len, unsigned int samples)
         h[2] = __builtin_ia32_crc32di(h[2], dp[step * 2]);
 
     return h[0] + (h[1] << 10) + (h[2] << 21) + (h[3] << 32);
-// #else
-//     return fnv_hash(data, len);
-// #endif
+#else
+    return fnv_hash(data, len);
+#endif
 }
 
 static void update_irq(NV2AState *d)


### PR DESCRIPTION
Added check for SSE 4.2 and glew so Linux compiles fine again.

Without this clang won't compile because of SSE 4.2 and OpenGL will fail quickly because all extensions are implicit.
Still gives a warning at link time because glFrameTerminator exists twice.
