### PR TITLE
Surface flip

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -2889,15 +2889,14 @@ static void pgraph_update_surface(NV2AState *d,
             glGenTextures(1, &pg->gl_color_buffer);
             glBindTexture(GL_TEXTURE_2D, pg->gl_color_buffer);
 
-#if 0 // Removed with flipped_buf
-            glPixelStorei(GL_UNPACK_ROW_LENGTH,
-                          pg->surface_color.pitch / f.bytes_per_pixel);
-#endif
-
-            uint8_t* flipped_buf = g_malloc(width * height * f.bytes_per_pixel);
+            /* This is VRAM so we can't do this inplace! */
+            uint8_t *flipped_buf = g_malloc(width * height * f.bytes_per_pixel);
             unsigned int irow;
             for (irow = 0; irow < height; irow++) {
-                memcpy(&flipped_buf[width * (height - irow - 1) * f.bytes_per_pixel], &buf[pg->surface_color.pitch * irow], width * f.bytes_per_pixel);
+                memcpy(&flipped_buf[width * (height - irow - 1)
+                                         * f.bytes_per_pixel],
+                       &buf[pg->surface_color.pitch * irow],
+                       width * f.bytes_per_pixel);
             }
 
             glTexImage2D(GL_TEXTURE_2D, 0, f.gl_internal_format,
@@ -2906,10 +2905,6 @@ static void pgraph_update_surface(NV2AState *d,
                          flipped_buf);
 
             g_free(flipped_buf);
-
-#if 0
-            glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-#endif
 
             glFramebufferTexture2D(GL_FRAMEBUFFER,
                                    GL_COLOR_ATTACHMENT0,
@@ -3084,15 +3079,14 @@ static void pgraph_update_surface(NV2AState *d,
             glGenTextures(1, &pg->gl_zeta_buffer);
             glBindTexture(GL_TEXTURE_2D, pg->gl_zeta_buffer);
 
-#if 0
-            glPixelStorei(GL_UNPACK_ROW_LENGTH,
-                          pg->surface_zeta.pitch / bytes_per_pixel);
-#endif
-
-            uint8_t* flipped_buf = g_malloc(width * height * bytes_per_pixel);
+            /* This is VRAM so we can't do this inplace! */
+            uint8_t *flipped_buf = g_malloc(width * height * bytes_per_pixel);
             unsigned int irow;
             for (irow = 0; irow < height; irow++) {
-                memcpy(&flipped_buf[width * (height - irow - 1) * bytes_per_pixel], &buf[pg->surface_zeta.pitch * irow], width * bytes_per_pixel);
+                memcpy(&flipped_buf[width * (height - irow - 1)
+                                         * bytes_per_pixel],
+                       &buf[pg->surface_zeta.pitch * irow],
+                       width * bytes_per_pixel);
             }
 
             glTexImage2D(GL_TEXTURE_2D, 0, gl_internal_format,
@@ -3101,10 +3095,6 @@ static void pgraph_update_surface(NV2AState *d,
                          flipped_buf);
 
             g_free(flipped_buf);
-
-#if 0
-            glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-#endif
 
             glFramebufferTexture2D(GL_FRAMEBUFFER,
                                    gl_attachment,

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -2889,13 +2889,27 @@ static void pgraph_update_surface(NV2AState *d,
             glGenTextures(1, &pg->gl_color_buffer);
             glBindTexture(GL_TEXTURE_2D, pg->gl_color_buffer);
 
+#if 0 // Removed with flipped_buf
             glPixelStorei(GL_UNPACK_ROW_LENGTH,
                           pg->surface_color.pitch / f.bytes_per_pixel);
+#endif
+
+            uint8_t* flipped_buf = g_malloc(width * height * f.bytes_per_pixel);
+            unsigned int irow;
+            for (irow = 0; irow < height; irow++) {
+                memcpy(&flipped_buf[width * (height - irow - 1) * f.bytes_per_pixel], &buf[pg->surface_color.pitch * irow], width * f.bytes_per_pixel);
+            }
+
             glTexImage2D(GL_TEXTURE_2D, 0, f.gl_internal_format,
                          width, height, 0,
                          f.gl_format, f.gl_type,
-                         buf);
+                         flipped_buf);
+
+            g_free(flipped_buf);
+
+#if 0
             glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
 
             glFramebufferTexture2D(GL_FRAMEBUFFER,
                                    GL_COLOR_ATTACHMENT0,
@@ -3070,14 +3084,27 @@ static void pgraph_update_surface(NV2AState *d,
             glGenTextures(1, &pg->gl_zeta_buffer);
             glBindTexture(GL_TEXTURE_2D, pg->gl_zeta_buffer);
 
-
+#if 0
             glPixelStorei(GL_UNPACK_ROW_LENGTH,
                           pg->surface_zeta.pitch / bytes_per_pixel);
+#endif
+
+            uint8_t* flipped_buf = g_malloc(width * height * bytes_per_pixel);
+            unsigned int irow;
+            for (irow = 0; irow < height; irow++) {
+                memcpy(&flipped_buf[width * (height - irow - 1) * bytes_per_pixel], &buf[pg->surface_zeta.pitch * irow], width * bytes_per_pixel);
+            }
+
             glTexImage2D(GL_TEXTURE_2D, 0, gl_internal_format,
                          width, height, 0,
                          gl_format, gl_type,
-                         buf);
+                         flipped_buf);
+
+            g_free(flipped_buf);
+
+#if 0
             glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
 
             glFramebufferTexture2D(GL_FRAMEBUFFER,
                                    gl_attachment,


### PR DESCRIPTION
Flip surfaces before upload on surface changes.
Partly fixes ingame part of MASHED: Drive to Survive.
