### PR TITLE
GL debug

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -106,7 +106,7 @@ static void gl_debug_label(GLenum target, GLuint name, const char *fmt, ...)
 # define NV2A_GL_DGROUP_END() \
     gl_debug_group_end()
 # define NV2A_GL_DLABEL(target, name, format, ...)  \
-    gl_debug_label(target, name, "nv2a: " format, ## __VA_ARGS__)
+    gl_debug_label(target, name, "nv2a: { " format " }", ## __VA_ARGS__)
 
 #else
 # define NV2A_GL_DPRINTF(cc, format, ...)          do { } while (0)
@@ -1956,7 +1956,7 @@ static TextureBinding* generate_texture(const TextureShape s,
     glBindTexture(gl_target, gl_texture);
 
     NV2A_GL_DLABEL(GL_TEXTURE, gl_texture,
-                   "NV2A { Format: 0x%02X%s, Width: %i }",
+                   "format: 0x%02X%s, width: %i",
                    s.color_format, f.linear ? "" : " (SZ)", s.width);
 
     if (f.linear) {

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1876,6 +1876,9 @@ static TextureBinding* generate_texture(const TextureShape s,
     }
 
     glBindTexture(gl_target, gl_texture);
+    char label[256];
+    sprintf(label, "NV2A { Format: 0x%02X%s, Width: %i }",s.color_format,f.linear?"":" (SZ)",s.width);
+    glObjectLabel(GL_TEXTURE, gl_texture, strlen(label), label);
 
     if (f.linear) {
         /* Can't handle retarded strides */
@@ -3339,6 +3342,12 @@ static void pgraph_method(NV2AState *d,
 
         /* I guess this kicks it off? */
         if (image_blit->operation == NV09F_SET_OPERATION_SRCCOPY) {
+
+            char message[256];
+            sprintf(message,"NV2A: NV09F_SET_OPERATION_SRCCOPY");
+            glEnable(GL_DEBUG_OUTPUT); //FIXME: Elsewhere
+            glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION, GL_DEBUG_TYPE_MARKER, 0, GL_DEBUG_SEVERITY_NOTIFICATION, strlen(message), message);
+
             GraphicsObject *context_surfaces_obj =
                 lookup_graphics_object(pg, image_blit->context_surfaces);
             assert(context_surfaces_obj);


### PR DESCRIPTION
Add Texture labels so we can spot incorrect texture formats.
Plus: Make sure GL debuggers know about blitting.

There is a glEnable hack in this which should be removed if we handle enable debug contexts elsewhere (Debug GLO Context maybe? Does that work for all platforms? GLO debug using glEnable?).
