### PR TITLE
Fix GL3 mipmaps by forcing at least 1x1

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1982,6 +1982,8 @@ static TextureBinding* generate_texture(const TextureShape s,
 
         int level;
         for (level = 0; level < s.levels; level++) {
+            if (width < 1) width = 1;
+            if (height < 1) height = 1;
             if (f.gl_format == 0) { /* retarded way of indicating compressed */
                 unsigned int block_size;
                 if (f.gl_internal_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT) {


### PR DESCRIPTION
This is necessary in GL3.
We should probably add a cap in the for-loop too at some point by setting the max s.levels to max(log_width,log_height). I'll leave that to someone else or once we run into problems.

Fixes fonts in MASHED: DTS.
