### PR TITLE
Use newly converted buffer after conversion

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1835,7 +1835,7 @@ static void pgraph_bind_vertex_attributes(NV2AState *d,
                 glBindBuffer(GL_ARRAY_BUFFER, attribute->gl_converted_buffer);
                 glBufferData(GL_ARRAY_BUFFER,
                              num_elements * out_stride,
-                             data,
+                             attribute->converted_buffer,
                              GL_DYNAMIC_DRAW);
 
                 glVertexAttribPointer(i,


### PR DESCRIPTION
This looks like an oversight or Copy/Paste error.
Data is written to converted_buffer but uploaded from data.

IIRC fixes stuff in Halo?
