### PR TITLE
Fix texture format SZ_A8 (0x19)

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1175,7 +1175,7 @@ static const ColorFormatInfo kelvin_color_format_map[66] = {
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_A8R8G8B8] =
         {4, true, GL_RGBA8, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV},
     [NV097_SET_TEXTURE_FORMAT_COLOR_SZ_A8] =
-        {2, false, GL_R8, GL_RED, GL_UNSIGNED_BYTE,
+        {1, false, GL_R8, GL_RED, GL_UNSIGNED_BYTE,
          {GL_ZERO, GL_ZERO, GL_ZERO, GL_RED}},
     [NV097_SET_TEXTURE_FORMAT_COLOR_LU_IMAGE_X8R8G8B8] =
         {4, true, GL_RGB8, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV},


### PR DESCRIPTION
Fixes copyright and start message in DoA3.
