### PR TITLE
DXT hash length fix + don't load invalid GL-DXT mipmaps

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -2170,9 +2170,11 @@ static TextureBinding* generate_texture(const TextureShape s,
 
         int level;
         for (level = 0; level < s.levels; level++) {
-            if (width < 1) width = 1;
-            if (height < 1) height = 1;
+
             if (f.gl_format == 0) { /* retarded way of indicating compressed */
+
+                width = MAX(width, 4); height = MAX(height, 4);
+
                 unsigned int block_size;
                 if (f.gl_internal_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT) {
                     block_size = 8;
@@ -2180,16 +2182,16 @@ static TextureBinding* generate_texture(const TextureShape s,
                     block_size = 16;
                 }
 
-                if (width < 4) width = 4;
-                if (height < 4) height = 4;
-
                 glCompressedTexImage2D(gl_target, level, f.gl_internal_format,
                                        width, height, 0,
-                                       width/4 * height/4 * block_size,
+                                       width * height * block_size / 16,
                                        texture_data);
 
-                texture_data += width/4 * height/4 * block_size;
+                texture_data += width * height * block_size / 16;
             } else {
+
+                width = MAX(width, 1); height = MAX(height, 1);
+
                 unsigned int pitch = width * f.bytes_per_pixel;
                 uint8_t *unswizzled = g_malloc(height * pitch);
                 unswizzle_rect(texture_data, width, height,
@@ -2377,8 +2379,40 @@ static void pgraph_bind_textures(NV2AState *d)
             width = 1 << log_width;
             height = 1 << log_height;
 
-            if (max_mipmap_level < levels) {
-                levels = max_mipmap_level;
+            levels = MIN(levels, max_mipmap_level + 1);
+            if (f.gl_format != 0) {
+                /* Xbox / GL goes down to 1x? or ?x1:
+                 * >> Level 0: 32 x 4
+                 *    Level 1: 16 x 2
+                 *    Level 2: 8 x 1
+                 *    Level 3: 4 x 1
+                 *    Level 4: 2 x 1
+                 *    Level 5: 1 x 1
+                 */
+                levels = MIN(levels, MAX(log_width, log_height) + 1);
+            } else {
+                /* Compressed textures are handled differently in OpenGL.
+                 * While the other mipmaps are the same in Xbox and OpenGL, DXT
+                 * textures on Xbox can have smaller mipmaps too (probably).
+                 * https://msdn.microsoft.com/en-us/library/windows/desktop/bb694531%28v=vs.85%29.aspx
+                 * (Virtual Size versus Physical Size)
+                 *
+                 * GL Compressed goes down to 4x? or ?x4 and same size:
+                 * >> Level 0: 64 x 8
+                 *    Level 1: 32 x 4
+                 *    Level 2: 16 x 4 << BAD SIZE!
+                 * >> Level 0: 16 x 16
+                 *    Level 1: 8 x 8
+                 *    Level 2: 4 x 4 << OK!
+                 *
+                 * This behaviour was tested with MESA 10.6.2, GL 3.3 Core
+                 * It doesn't report errors but the read texels will be black.
+                 */
+                if ((log_width < 2) || (log_height < 2)) {
+                    levels = 0;
+                } else {
+                    levels = MIN(levels, MIN(log_width, log_height) - 1);
+                }
             }
         }
 
@@ -2408,12 +2442,30 @@ static void pgraph_bind_textures(NV2AState *d)
         if (f.linear) {
             length = height * pitch;
         } else {
-            unsigned int w = width, h = height;
             int level;
-            for (level = 0; level < levels; level++) {
-                length += w * h * f.bytes_per_pixel;
-                w /= 2;
-                h /= 2;
+            unsigned int w = width, h = height;
+            if (f.gl_format != 0) {
+
+                for (level = 0; level < levels; level++) {
+                    w = MAX(w, 1); h = MAX(h, 1);
+                    length += w * h * f.bytes_per_pixel;
+                    w /= 2; h /= 2;
+                }
+            } else {
+                /* Compressed textures are a bit different */
+
+                unsigned int block_size;
+                if (f.gl_internal_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT) {
+                    block_size = 8;
+                } else {
+                    block_size = 16;
+                }
+
+                for (level = 0; level < levels; level++) {
+                    w = MAX(w, 4); h = MAX(h, 4);
+                    length += w * h * block_size / 16;
+                    w /= 2; h /= 2;
+                }
             }
         }
 


### PR DESCRIPTION
This should fix the DXT bugs with GL3 by simply disabling the mipmap levels which break GL.
I couldn't find a spec about DXT Mesa textures or GL DXT textures in general.

However, my intel Mesa has trouble loading DXT textures which are not at least 4x4. Even if they are 4x4 they must have the same aspect ratio as the other mipmap levels.
So after 16x8 comes 8x4 and 4x4 wouldn't work anymore because it's not the correct aspect ratio.
However, with 16x16 it would have 16x16,8x8 _AND_ 4x4.
There is probably a bug in Mesa/libdxtc which causes it not to signal an error: Uploading a wrong DXT mipmap level will be silent, but still cause vec4(0.0) samples in the fragment shader.
I have tried to comment it in the code for future changes.

Usually this problem arises with textures which seem to have auto-generated mipmaps. I have seen this with THPS2X and Halo. Both have broken DXT mipmaps which go down to 1x1, all mipmaps (level > 0) only contain a portion of the actual image. I believe this is a bug in some XDK.

By clamping the levels value we can avoid being stuck on standard 1x1 texture levels (if the texture has a broken mipmap level value) + we avoid loading invalid DXT mipmaps.
### This should be tested on different drivers / GPUs.

Any input (especially specs) is welcome too.

While I was at it I decided to fix the DXT hash length too.
