### PR TITLE
Improve GL Draw calls and fix DRAW_ARRAYS (+Vertex3f)

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -912,6 +912,7 @@ static void gl_debug_label(GLenum target, GLuint name, const char *fmt, ...)
 #   define NV097_SET_VIEWPORT_SCALE                           0x00970AF0
 #   define NV097_SET_TRANSFORM_PROGRAM                        0x00970B00
 #   define NV097_SET_TRANSFORM_CONSTANT                       0x00970B80
+#   define NV097_SET_VERTEX3F                                 0x00971500
 #   define NV097_SET_VERTEX4F                                 0x00971518
 #   define NV097_SET_VERTEX_DATA_ARRAY_OFFSET                 0x00971720
 #   define NV097_SET_VERTEX_DATA_ARRAY_FORMAT                 0x00971760
@@ -4772,6 +4773,20 @@ static void pgraph_method(NV2AState *d,
         if (slot % 4 == 3) {
             SET_MASK(pg->regs[NV_PGRAPH_CHEOPS_OFFSET],
                      NV_PGRAPH_CHEOPS_OFFSET_CONST_LD_PTR, const_load+1);
+        }
+        break;
+    }
+
+    case NV097_SET_VERTEX3F ...
+            NV097_SET_VERTEX3F + 8: {
+        slot = (class_method - NV097_SET_VERTEX3F) / 4;
+        VertexAttribute *attribute =
+            &pg->vertex_attributes[NV2A_VERTEX_ATTR_POSITION];
+        pgraph_allocate_inline_buffer_vertices(pg, NV2A_VERTEX_ATTR_POSITION);
+        attribute->inline_value[slot] = *(float*)&parameter;
+        attribute->inline_value[3] = 1.0f;
+        if (slot == 2) {
+            pgraph_finish_inline_buffer_vertex(pg);
         }
         break;
     }

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1593,6 +1593,12 @@ typedef struct PGRAPHState {
 
     unsigned int inline_buffer_length;
 
+    unsigned int draw_arrays_length;
+    unsigned int draw_arrays_max_count;
+    /* FIXME: Unknown size, possibly endless, 1000 will do for now */
+    GLint gl_draw_arrays_start[1000];
+    GLsizei gl_draw_arrays_count[1000];
+
     GLuint gl_element_buffer;
     GLuint gl_memory_buffer;
 
@@ -2073,6 +2079,7 @@ static unsigned int pgraph_bind_inline_array(NV2AState *d)
             NV2A_DPRINTF("bind inline attribute %d size=%d, count=%d\n",
                 i, attribute->size, attribute->count);
             offset += attribute->size * attribute->count;
+            assert(offset % 4 == 0);
         }
     }
 
@@ -4952,7 +4959,28 @@ static void pgraph_method(NV2AState *d,
                                 & NV_PGRAPH_CONTROL_1_STENCIL_TEST_ENABLE;
 
         if (parameter == NV097_SET_BEGIN_END_OP_END) {
-            if (pg->inline_buffer_length) {
+
+            if (pg->draw_arrays_length) {
+
+                NV2A_GL_DPRINTF(false, "Draw Arrays");
+
+                assert(pg->inline_buffer_length == 0);
+                assert(pg->inline_array_length == 0);
+                assert(pg->inline_elements_length == 0);
+
+                pgraph_bind_vertex_attributes(d, pg->draw_arrays_max_count,
+                                              false, 0);
+                glMultiDrawArrays(pg->gl_primitive_mode,
+                                  pg->gl_draw_arrays_start,
+                                  pg->gl_draw_arrays_count,
+                                  pg->draw_arrays_length);
+            } else if (pg->inline_buffer_length) {
+
+                NV2A_GL_DPRINTF(false, "Inline Buffer");
+
+                assert(pg->draw_arrays_length == 0);
+                assert(pg->inline_array_length == 0);
+                assert(pg->inline_elements_length == 0);
 
                 for (i = 0; i < NV2A_VERTEXSHADER_ATTRIBUTES; i++) {
                     VertexAttribute *attribute = &pg->vertex_attributes[i];
@@ -4984,10 +5012,22 @@ static void pgraph_method(NV2AState *d,
                 glDrawArrays(pg->gl_primitive_mode,
                              0, pg->inline_buffer_length);
             } else if (pg->inline_array_length) {
+
+                NV2A_GL_DPRINTF(false, "Inline Array");
+
+                assert(pg->draw_arrays_length == 0);
+                assert(pg->inline_buffer_length == 0);
+                assert(pg->inline_elements_length == 0);
+
                 unsigned int index_count = pgraph_bind_inline_array(d);
                 glDrawArrays(pg->gl_primitive_mode, 0, index_count);
             } else if (pg->inline_elements_length) {
 
+                NV2A_GL_DPRINTF(false, "Inline Elements");
+
+                assert(pg->draw_arrays_length == 0);
+                assert(pg->inline_buffer_length == 0);
+                assert(pg->inline_array_length == 0);
 
                 uint32_t max_element = 0;
                 uint32_t min_element = (uint32_t)-1;
@@ -5004,14 +5044,16 @@ static void pgraph_method(NV2AState *d,
                              pg->inline_elements,
                              GL_DYNAMIC_DRAW);
 
-                glDrawElements(pg->gl_primitive_mode,
-                               pg->inline_elements_length,
-                               GL_UNSIGNED_INT,
-                               (void*)0);
+                glDrawRangeElements(pg->gl_primitive_mode,
+                                    min_element, max_element,
+                                    pg->inline_elements_length,
+                                    GL_UNSIGNED_INT,
+                                    (void*)0);
 
-            }/* else {
+            } else {
+                NV2A_GL_DPRINTF(true, "EMPTY NV097_SET_BEGIN_END");
                 assert(false);
-            }*/
+            }
 
             /* End of visibility testing */
             if (pg->zpass_pixel_count_enable) {
@@ -5154,6 +5196,8 @@ static void pgraph_method(NV2AState *d,
             pg->inline_elements_length = 0;
             pg->inline_array_length = 0;
             pg->inline_buffer_length = 0;
+            pg->draw_arrays_length = 0;
+            pg->draw_arrays_max_count = 0;
 
             /* Visibility testing */
             if (pg->zpass_pixel_count_enable) {
@@ -5277,12 +5321,29 @@ static void pgraph_method(NV2AState *d,
             pg->inline_elements_length++] = parameter;
         break;
     case NV097_DRAW_ARRAYS: {
+
         unsigned int start = GET_MASK(parameter, NV097_DRAW_ARRAYS_START_INDEX);
         unsigned int count = GET_MASK(parameter, NV097_DRAW_ARRAYS_COUNT)+1;
 
-        pgraph_bind_vertex_attributes(d, start + count, false, 0);
-        glDrawArrays(pg->gl_primitive_mode, start, count);
+        pg->draw_arrays_max_count = MAX(pg->draw_arrays_max_count, start + count);
 
+        assert(pg->draw_arrays_length < sizeof(pg->gl_draw_arrays_start) / sizeof(pg->gl_draw_arrays_start[0]));
+
+        /* Attempt to connect primitives */
+        if (pg->draw_arrays_length > 0) {
+            unsigned int last_start =
+                pg->gl_draw_arrays_start[pg->draw_arrays_length - 1];
+            unsigned int* last_count =
+                &pg->gl_draw_arrays_count[pg->draw_arrays_length - 1];
+            if (start == (last_start + *last_count)) {
+                *last_count += count;
+                break;
+            }
+        }
+
+        pg->gl_draw_arrays_start[pg->draw_arrays_length] = start;
+        pg->gl_draw_arrays_count[pg->draw_arrays_length] = count;
+        pg->draw_arrays_length++;
         break;
     }
     case NV097_INLINE_ARRAY:


### PR DESCRIPTION
This is my branch to figure out why we are missing so many primitives in games like THPS2X.

I started by adding assertions to the draws so we are notified if different draw types happen at once.
We should probably just get rid of the "else"-crap in BEGIN_END in the future and count the number of different methods and assert if it's higher than 1.
I also threw in an assertion for the alignment of the vertex attributes which should be 32 bits [alignment code still missing from this PR! only asserts!].

I also decided to use DrawRangeElements because apitrace kept complaining about the missing range (and we have the proper values anyway).

The most important change by far is the merging of tightly packed vertices [which Xbox D3D should always produce unless the games use handcrafted pushbuffers?].
To understand the problem: DRAW_ARRAYS (non-indexed from VB) has START_INDEX and COUNT parameters.
The COUNT parameter is only 8 bits and represents a value in the range [1;256]. So if, for example, a TRI_FAN with 650 vertices is uploaded it will be broken into 3 DRAW_ARRAYS:

```
BEGIN(TRI_FAN)
DRAW_ARRAYS(START_INDEX=0, COUNT=256)
DRAW_ARRAYS(START_INDEX=256, COUNT=256)
DRAW_ARRAYS(START_INDEX=512, COUNT=138)
END
```

We can't simply call glDrawArrays three times because the first vertex of the first call would mark the base vertex for the triangle fan. All following 255 vertices of the first draw call would be connected to it (which is correct).
However, in the second and third draw call, GL would interpret the newly submitted vertices [index 256 and 512 respectively] as base vertex (which is wrong, we still want vertex 0 as base).
The same problems exists with any primitive which reuses a vertex including triangle strips, line loops etc. etc.
It is still unknown if the Xbox GPU will use a new base vertex if there is a gap in the provided indices [last_START_INDEX+last_COUNT != START_INDEX].
We shouldn't have to worry about it for now because Xbox D3D should only produce tightly packed DRAW_ARRAYS.
As we do HW emulation rather than HLE we should probably still work on it in the future.

Furthermore I added glMultiDrawArrays which kicks in if the merging is disabled. It's currently limited to 1000 chunks [implemented in the worst way possible =P ].
We could possibly also avoid the split for some data types so I thought it would be a good addition.

I also added Vertex3f just for the sake of completeness.

This probably needs some work and testing before being merged?
