### PR TITLE
Clear framebuffers so we don't have different sizes per attachment

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -3379,6 +3379,7 @@ static bool pgraph_zeta_write_enabled(PGRAPHState *pg)
 
 static void pgraph_set_surface_dirty(PGRAPHState *pg, bool color, bool zeta)
 {
+    /* FIXME: Does this apply to CLEARs too? */
     color = color && pgraph_color_write_enabled(pg);
     zeta = zeta && pgraph_zeta_write_enabled(pg);
     pg->surface_color.draw_dirty |= color;
@@ -3397,6 +3398,7 @@ static void pgraph_update_surface(NV2AState *d,
     pgraph_get_surface_dimensions(pg, &width, &height);
     pgraph_apply_anti_aliasing_factor(pg, &width, &height);
 
+    /* FIXME: Does this apply to CLEARs too? */
     color = color && pgraph_color_write_enabled(pg);
     zeta = zeta && pgraph_zeta_write_enabled(pg);
 

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -3407,6 +3407,30 @@ static void pgraph_update_surface(NV2AState *d,
         pg->surface_color.buffer_dirty = true;
         pg->surface_zeta.buffer_dirty = true;
 
+        glFramebufferTexture2D(GL_FRAMEBUFFER,
+                               GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_2D,
+                               0, 0);
+
+        if (pg->gl_color_buffer) {
+            glDeleteTextures(1, &pg->gl_color_buffer);
+            pg->gl_color_buffer = 0;
+        }
+
+        glFramebufferTexture2D(GL_FRAMEBUFFER,
+                               GL_DEPTH_ATTACHMENT,
+                               GL_TEXTURE_2D,
+                               0, 0);
+        glFramebufferTexture2D(GL_FRAMEBUFFER,
+                               GL_DEPTH_STENCIL_ATTACHMENT,
+                               GL_TEXTURE_2D,
+                               0, 0);
+
+        if (pg->gl_zeta_buffer) {
+            glDeleteTextures(1, &pg->gl_zeta_buffer);
+            pg->gl_zeta_buffer = 0;
+        }
+
         memcpy(&pg->last_surface_shape, &pg->surface_shape,
                sizeof(SurfaceShape));
     }


### PR DESCRIPTION
Different attachment sizes will limit the draw/clear region to the smallest buffer which causes a ton of issues.
Also added a FIXME about CLEAR which might not respect the writemasks (needs research).
