### PR TITLE
Fog

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -261,9 +261,19 @@
 #   define NV_PGRAPH_CHANNEL_CTX_TRIGGER_WRITE_OUT              (1 << 1)
 #define NV_PGRAPH_CSV0_D                                 0x00000FB4
 #   define NV_PGRAPH_CSV0_D_RANGE_MODE                          (1 << 18)
+#   define NV_PGRAPH_CSV0_D_FOGENABLE                           (1 << 19)
 #   define NV_PGRAPH_CSV0_D_TEXGEN_REF                          (1 << 20)
 #       define NV_PGRAPH_CSV0_D_TEXGEN_REF_LOCAL_VIEWER             0
 #       define NV_PGRAPH_CSV0_D_TEXGEN_REF_INFINITE_VIEWER          1
+#   define NV_PGRAPH_CSV0_D_FOG_MODE                            (1 << 21)
+#       define NV_PGRAPH_CSV0_D_FOG_MODE_LINEAR                     0
+#       define NV_PGRAPH_CSV0_D_FOG_MODE_EXP                        1
+#   define NV_PGRAPH_CSV0_D_FOGGENMODE                          0x01C00000
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_SPEC_ALPHA               0
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_RADIAL                   1
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_PLANAR                   2
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_ABS_PLANAR               3
+#       define NV_PGRAPH_CSV0_D_FOGGENMODE_FOG_X                    4
 #   define NV_PGRAPH_CSV0_D_MODE                                0xC0000000
 #   define NV_PGRAPH_CSV0_D_SKIN                                0x1C000000
 #       define NV_PGRAPH_CSV0_D_SKIN_OFF                            0
@@ -405,6 +415,22 @@
 #       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_INVERT              6
 #       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_INCR                7
 #       define NV_PGRAPH_CONTROL_2_STENCIL_OP_V_DECR                8
+#define NV_PGRAPH_CONTROL_3                              0x00001958
+#   define NV_PGRAPH_CONTROL_3_FOGENABLE                        (1 << 8)
+#   define NV_PGRAPH_CONTROL_3_FOG_MODE                         0x00070000
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR                  0
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP                     1
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2                    3
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP_ABS                 5
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2_ABS                7
+#       define NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR_ABS              4
+#define NV_PGRAPH_FOGCOLOR                               0x00001980
+#   define NV_PGRAPH_FOGCOLOR_RED                               0x00FF0000
+#   define NV_PGRAPH_FOGCOLOR_GREEN                             0x0000FF00
+#   define NV_PGRAPH_FOGCOLOR_BLUE                              0x000000FF
+#   define NV_PGRAPH_FOGCOLOR_ALPHA                             0xFF000000
+#define NV_PGRAPH_FOGPARAM0                              0x00001984
+#define NV_PGRAPH_FOGPARAM1                              0x00001988
 #define NV_PGRAPH_SETUPRASTER                            0x00001990
 #   define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE                  0x00000003
 #       define NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_FILL             0
@@ -716,6 +742,25 @@
 #   define NV097_SET_CONTROL0                                 0x00970290
 #       define NV097_SET_CONTROL0_STENCIL_WRITE_ENABLE            (1 << 0)
 #       define NV097_SET_CONTROL0_Z_FORMAT                        (1 << 12)
+#   define NV097_SET_FOG_MODE                                 0x0097029C
+#       define NV097_SET_FOG_MODE_V_LINEAR                        0x2601
+#       define NV097_SET_FOG_MODE_V_EXP                           0x800
+#       define NV097_SET_FOG_MODE_V_EXP2                          0x801
+#       define NV097_SET_FOG_MODE_V_EXP_ABS                       0x802
+#       define NV097_SET_FOG_MODE_V_EXP2_ABS                      0x803
+#       define NV097_SET_FOG_MODE_V_LINEAR_ABS                    0x804
+#   define NV097_SET_FOG_GEN_MODE                             0x009702A0
+#       define NV097_SET_FOG_GEN_MODE_V_SPEC_ALPHA                0
+#       define NV097_SET_FOG_GEN_MODE_V_RADIAL                    1
+#       define NV097_SET_FOG_GEN_MODE_V_PLANAR                    2
+#       define NV097_SET_FOG_GEN_MODE_V_ABS_PLANAR                3
+#       define NV097_SET_FOG_GEN_MODE_V_FOG_X                     6
+#   define NV097_SET_FOG_ENABLE                               0x009702A4
+#   define NV097_SET_FOG_COLOR                                0x009702A8
+#       define NV097_SET_FOG_COLOR_RED                            0x000000FF
+#       define NV097_SET_FOG_COLOR_GREEN                          0x0000FF00
+#       define NV097_SET_FOG_COLOR_BLUE                           0x00FF0000
+#       define NV097_SET_FOG_COLOR_ALPHA                          0xFF000000
 #   define NV097_SET_ALPHA_TEST_ENABLE                        0x00970300
 #   define NV097_SET_BLEND_ENABLE                             0x00970304
 #   define NV097_SET_CULL_FACE_ENABLE                         0x00970308
@@ -825,9 +870,11 @@
 #   define NV097_SET_INVERSE_MODEL_VIEW_MATRIX                0x00970580
 #   define NV097_SET_COMPOSITE_MATRIX                         0x00970680
 #   define NV097_SET_TEXTURE_MATRIX                           0x009706C0
+#   define NV097_SET_FOG_PARAMS                               0x009709C0
 #   define NV097_SET_TEXGEN_VIEW_MODEL                        0x009709CC
 #       define NV097_SET_TEXGEN_VIEW_MODEL_LOCAL_VIEWER           0
 #       define NV097_SET_TEXGEN_VIEW_MODEL_INFINITE_VIEWER        1
+#   define NV097_SET_FOG_PLANE                                0x009709D0
 #   define NV097_SET_VIEWPORT_OFFSET                          0x00970A20
 #   define NV097_SET_COMBINER_FACTOR0                         0x00970A60
 #   define NV097_SET_COMBINER_FACTOR1                         0x00970A80
@@ -1451,6 +1498,9 @@ typedef struct PGRAPHState {
     float projection_matrix[16];
     float inverse_model_view_matrix[4][16]; /* 4 weights with 4x4 matrix each */
     float model_view_matrix[4][16]; /* 4 weights with 4x4 matrix each */
+
+    /* FIXME: Also in vshader consts? */
+    float fog_plane[4];
 
     /* FIXME: Move to NV_PGRAPH_BUMPMAT... */
     float bump_env_matrix[3][4]; /* 4 stages with 2x2 matrix each */
@@ -3907,6 +3957,71 @@ static void pgraph_method(NV2AState *d,
         break;
     }
 
+    case NV097_SET_FOG_MODE: {
+        /* FIXME: There is also NV_PGRAPH_CSV0_D_FOG_MODE */
+        unsigned int mode;
+        switch (parameter) {
+        case NV097_SET_FOG_MODE_V_LINEAR:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR; break;
+        case NV097_SET_FOG_MODE_V_EXP:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_EXP; break;
+        case NV097_SET_FOG_MODE_V_EXP2:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2; break;
+        case NV097_SET_FOG_MODE_V_EXP_ABS:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_EXP_ABS; break;
+        case NV097_SET_FOG_MODE_V_EXP2_ABS:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_EXP2_ABS; break;
+        case NV097_SET_FOG_MODE_V_LINEAR_ABS:
+            mode = NV_PGRAPH_CONTROL_3_FOG_MODE_LINEAR_ABS; break;
+        default:
+            assert(false);
+            break;
+        }
+        SET_MASK(pg->regs[NV_PGRAPH_CONTROL_3], NV_PGRAPH_CONTROL_3_FOG_MODE,
+                 mode);
+        break;
+    }
+    case NV097_SET_FOG_GEN_MODE: {
+        unsigned int mode;
+        switch (parameter) {
+        case NV097_SET_FOG_GEN_MODE_V_SPEC_ALPHA:
+            mode = NV_PGRAPH_CSV0_D_FOGGENMODE_SPEC_ALPHA; break;
+        case NV097_SET_FOG_GEN_MODE_V_RADIAL:
+            mode = NV_PGRAPH_CSV0_D_FOGGENMODE_RADIAL; break;
+        case NV097_SET_FOG_GEN_MODE_V_PLANAR:
+            mode = NV_PGRAPH_CSV0_D_FOGGENMODE_PLANAR; break;
+        case NV097_SET_FOG_GEN_MODE_V_ABS_PLANAR:
+            mode = NV_PGRAPH_CSV0_D_FOGGENMODE_ABS_PLANAR; break;
+        case NV097_SET_FOG_GEN_MODE_V_FOG_X:
+            mode = NV_PGRAPH_CSV0_D_FOGGENMODE_FOG_X; break;
+        default:
+            assert(false);
+            break;
+        }
+        SET_MASK(pg->regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_FOGGENMODE, mode);
+        break;
+    }
+    case NV097_SET_FOG_ENABLE:
+/*
+      FIXME: There is also:
+        SET_MASK(pg->regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_FOGENABLE,
+             parameter);
+*/
+        SET_MASK(pg->regs[NV_PGRAPH_CONTROL_3], NV_PGRAPH_CONTROL_3_FOGENABLE,
+             parameter);
+        break;
+    case NV097_SET_FOG_COLOR: {
+        /* PGRAPH channels are ARGB, parameter channels are ABGR */
+        uint8_t red = GET_MASK(parameter, NV097_SET_FOG_COLOR_RED);
+        uint8_t green = GET_MASK(parameter, NV097_SET_FOG_COLOR_GREEN);
+        uint8_t blue = GET_MASK(parameter, NV097_SET_FOG_COLOR_BLUE);
+        uint8_t alpha = GET_MASK(parameter, NV097_SET_FOG_COLOR_ALPHA);
+        SET_MASK(pg->regs[NV_PGRAPH_FOGCOLOR], NV_PGRAPH_FOGCOLOR_RED, red);
+        SET_MASK(pg->regs[NV_PGRAPH_FOGCOLOR], NV_PGRAPH_FOGCOLOR_GREEN, green);
+        SET_MASK(pg->regs[NV_PGRAPH_FOGCOLOR], NV_PGRAPH_FOGCOLOR_BLUE, blue);
+        SET_MASK(pg->regs[NV_PGRAPH_FOGCOLOR], NV_PGRAPH_FOGCOLOR_ALPHA, alpha);
+        break;
+    }
     case NV097_SET_ALPHA_TEST_ENABLE:
         SET_MASK(pg->regs[NV_PGRAPH_CONTROL_0],
                  NV_PGRAPH_CONTROL_0_ALPHATESTENABLE, parameter);
@@ -4240,9 +4355,20 @@ static void pgraph_method(NV2AState *d,
         pg->texture_matrix[slot / 16][slot % 16] = *(float*)&parameter;
         break;
 
+    case NV097_SET_FOG_PARAMS ...
+            NV097_SET_FOG_PARAMS + 8:
+        slot = (class_method - NV097_SET_FOG_PARAMS) / 4;
+        pg->regs[NV_PGRAPH_FOGPARAM0 + slot*4] = parameter;
+        break;
     case NV097_SET_TEXGEN_VIEW_MODEL:
         SET_MASK(pg->regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_TEXGEN_REF,
                  parameter);
+        break;
+
+    case NV097_SET_FOG_PLANE ...
+            NV097_SET_FOG_PLANE + 12:
+        slot = (class_method - NV097_SET_FOG_PLANE) / 4;
+        pg->fog_plane[slot] = *(float*)&parameter;
         break;
 
     case NV097_SET_VIEWPORT_OFFSET ...

--- a/hw/xbox/nv2a_psh.c
+++ b/hw/xbox/nv2a_psh.c
@@ -281,7 +281,7 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
         }
         break;
     case PS_REGISTER_FOG:
-        return qstring_from_str("clamp(pFog, 0.0, 1.0)");
+        return qstring_from_str("pFog");
     case PS_REGISTER_V0:
         return qstring_from_str("v0");
     case PS_REGISTER_V1:
@@ -546,7 +546,7 @@ static QString* psh_convert(struct PixelShader *ps)
     qstring_append(vars, "vec4 pD1 = vtx.D1 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pB0 = vtx.B0 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pB1 = vtx.B1 / vtx.inv_w;\n");
-    qstring_append(vars, "vec4 pFog = vtx.Fog / vtx.inv_w;\n");
+    qstring_append(vars, "vec4 pFog = clamp(vtx.Fog / vtx.inv_w, 0.0, 1.0);\n");
     qstring_append(vars, "vec4 pT0 = vtx.T0 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pT1 = vtx.T1 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pT2 = vtx.T2 / vtx.inv_w;\n");
@@ -554,7 +554,6 @@ static QString* psh_convert(struct PixelShader *ps)
     qstring_append(vars, "\n");
     qstring_append(vars, "vec4 v0 = pD0;\n");
     qstring_append(vars, "vec4 v1 = pD1;\n");
-    qstring_append(vars, "float fog = pFog.x;\n");
 
     ps->code = qstring_new();
 

--- a/hw/xbox/nv2a_psh.c
+++ b/hw/xbox/nv2a_psh.c
@@ -539,6 +539,7 @@ static QString* psh_convert(struct PixelShader *ps)
     qstring_append(preflight, "\n");
     qstring_append(preflight, "out vec4 fragColor;\n");
     qstring_append(preflight, "\n");
+    qstring_append(preflight, "uniform vec4 fogColor;\n");
 
     /* calculate perspective-correct inputs */
     QString *vars = qstring_new();
@@ -546,7 +547,7 @@ static QString* psh_convert(struct PixelShader *ps)
     qstring_append(vars, "vec4 pD1 = vtx.D1 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pB0 = vtx.B0 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pB1 = vtx.B1 / vtx.inv_w;\n");
-    qstring_append(vars, "vec4 pFog = clamp(vtx.Fog / vtx.inv_w, 0.0, 1.0);\n");
+    qstring_append(vars, "vec4 pFog = vec4(fogColor.rgb, clamp(vtx.Fog / vtx.inv_w, 0.0, 1.0));\n");
     qstring_append(vars, "vec4 pT0 = vtx.T0 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pT1 = vtx.T1 / vtx.inv_w;\n");
     qstring_append(vars, "vec4 pT2 = vtx.T2 / vtx.inv_w;\n");

--- a/hw/xbox/nv2a_psh.c
+++ b/hw/xbox/nv2a_psh.c
@@ -280,9 +280,8 @@ static QString* get_var(struct PixelShader *ps, int reg, bool is_dest)
             return qstring_from_str("c_0_1");
         }
         break;
-    case PS_REGISTER_FOG: // TODO
-        //return qstring_from_str("fog");
-        return qstring_from_str("vec4(1.0)");
+    case PS_REGISTER_FOG:
+        return qstring_from_str("clamp(pFog, 0.0, 1.0)");
     case PS_REGISTER_V0:
         return qstring_from_str("v0");
     case PS_REGISTER_V1:

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -319,7 +319,7 @@ static QString* generate_fixed_function(const ShaderState state,
              *    fogParam[0] = 1.5
              */
 
-            qstring_append(s, "float fogFactor = fogParam[0] + exp(fogDistance * fogParam[1] * 2.0 * 5.5452);\n");
+            qstring_append(s, "float fogFactor = fogParam[0] + exp2(fogDistance * fogParam[1] * 16.0);\n");
             qstring_append(s, "fogFactor -= 1.5;\n"); /* FIXME: WHHYYY?!! */
             break;
         case FOG_MODE_EXP2:
@@ -330,7 +330,7 @@ static QString* generate_fixed_function(const ShaderState state,
              *    fogParam[0] = 1.5
              */
 
-            qstring_append(s, "float fogFactor = fogParam[0] + exp(-fogDistance * fogDistance * fogParam[1] * fogParam[1] * 4.0 * 5.5452);\n");
+            qstring_append(s, "float fogFactor = fogParam[0] + exp2(-fogDistance * fogDistance * fogParam[1] * fogParam[1] * 32.0);\n");
             qstring_append(s, "fogFactor -= 1.5;\n"); /* FIXME: WHHYYY?!! */
             break;
         default:

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -329,12 +329,11 @@ static QString* generate_fixed_function(const ShaderState state,
             break;
         }
         /* FIXME: What about fog alpha?! */
-        qstring_append(s, "vec4 tFog = vec4(fogColor.rgb, fogFactor);\n");
+        qstring_append(s, "float tFog = fogFactor;\n");
     } else {
         /* FIXME: Is the fog still calculated / passed somehow?!
-         * Maybe vec4(fogColor, fogCoord) ?
          */
-        qstring_append(s, "vec4 tFog = vec4(0.0);\n");
+        qstring_append(s, "float tFog = 0.0;\n");
     }
 
     /* If skinning is off the composite matrix already includes the MV matrix */

--- a/hw/xbox/nv2a_shaders.h
+++ b/hw/xbox/nv2a_shaders.h
@@ -65,6 +65,10 @@ typedef struct ShaderState {
     bool texture_matrix_enable[4];
     enum VshTexgen texgen[4][4];
 
+    bool fog_enable;
+    enum VshFoggen foggen;
+    enum VshFogMode fog_mode;
+
     enum VshSkinning skinning;
 
     bool normalization;

--- a/hw/xbox/nv2a_shaders_common.h
+++ b/hw/xbox/nv2a_shaders_common.h
@@ -27,7 +27,7 @@
                            "  vec4 D1;\n" \
                            "  vec4 B0;\n" \
                            "  vec4 B1;\n" \
-                           "  vec4 Fog;\n" \
+                           "  float Fog;\n" \
                            "  vec4 T0;\n" \
                            "  vec4 T1;\n" \
                            "  vec4 T2;\n" \

--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -737,6 +737,7 @@ QString* vsh_translate(uint16_t version,
     qstring_append(header, STRUCT_VERTEX_DATA);
     qstring_append_fmt(header, "noperspective out VertexData %c_vtx;\n", out_prefix);
     qstring_append_fmt(header, "#define vtx %c_vtx", out_prefix);
+
     qstring_append(header, "\n"
                            "uniform mat4 texMat0;\n"
                            "uniform mat4 texMat1;\n"
@@ -780,7 +781,7 @@ QString* vsh_translate(uint16_t version,
     qstring_append(body, "vtx.D1 = clamp(oD1, 0.0, 1.0) * vtx.inv_w;\n");
     qstring_append(body, "vtx.B0 = clamp(oB0, 0.0, 1.0) * vtx.inv_w;\n");
     qstring_append(body, "vtx.B1 = clamp(oB1, 0.0, 1.0) * vtx.inv_w;\n");
-    qstring_append(body, "vtx.Fog = oFog * vtx.inv_w;\n");
+    qstring_append(body, "vtx.Fog = oFog.x * vtx.inv_w;\n");
     qstring_append(body, "vtx.T0 = oT0 * vtx.inv_w;\n");
     qstring_append(body, "vtx.T1 = oT1 * vtx.inv_w;\n");
     qstring_append(body, "vtx.T2 = oT2 * vtx.inv_w;\n");

--- a/hw/xbox/nv2a_vsh.h
+++ b/hw/xbox/nv2a_vsh.h
@@ -33,6 +33,27 @@ enum VshTexgen {
     TEXGEN_REFLECTION_MAP,
 };
 
+enum VshFogMode {
+    FOG_MODE_LINEAR,
+    FOG_MODE_EXP,
+    FOG_MODE_ERROR2, /* Doesn't exist */
+    FOG_MODE_EXP2,
+    FOG_MODE_LINEAR_ABS,
+    FOG_MODE_EXP_ABS,
+    FOG_MODE_ERROR6, /* Doesn't exist */
+    FOG_MODE_EXP2_ABS
+};
+
+enum VshFoggen {
+    FOGGEN_SPEC_ALPHA,
+    FOGGEN_RADIAL,
+    FOGGEN_PLANAR,
+    FOGGEN_ABS_PLANAR,
+    FOGGEN_ERROR4,
+    FOGGEN_ERROR5,
+    FOGGEN_FOG_X
+};
+
 enum VshSkinning {
     SKINNING_OFF,
     SKINNING_1WEIGHTS,


### PR DESCRIPTION
I've been using [this table (fog-formulas.ods)](https://docs.google.com/spreadsheets/d/1JOdmIRcxu9ZP7L0i2o5KULEUKwoXmIYiOjNeT85WW54/edit?usp=sharing) to figure out how to use the fog values. (Ignore the conditional formating, google sheets sucks - it works fine in my local copy using libreoffice)

The fog looks correct to me (tested EXP, EXP2 in Planar mode. Implemented the others using tons of GL material as reference).

I'm not sure which fog regs to use: `NV_PGRAPH_CSV0_D_FOG_MODE` vs. `NV_PGRAPH_CONTROL_3`. I chose the later for now.
Also I'm not sure where FogGen and Fog reside in the pipeline.
I'm guessing FogGen can also happen with vertex programs.
I did not fix the code after rebasing (it still has code paths for ffp and vp) but it can't break anything either (only the ffp code will ever happen). We should fix and move the FogGen soon - but this gets the job done for now.

A slightly different topic to end this PR:
We are getting errors with vertex shader based fog because of different float math in GLSL and the xbox GPU OR something related to Inf or NaN fog. I'll be looking into it and try to make VP a little more accurate in the futurue but it's not a priority. If an xbox app uses a VP and is entirely covered in fog it's most likely that it does something like "MAD <distance>, -INF, +INF" (which GLSL does different from the xbox).

[This was rebased because it was written before nv2a_shaders.c - it wasn't tested too much since]

**Test please?**
