### PR TITLE
Texgen

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -825,6 +825,10 @@
 #   define NV097_SET_INVERSE_MODEL_VIEW_MATRIX                0x00970580
 #   define NV097_SET_COMPOSITE_MATRIX                         0x00970680
 #   define NV097_SET_TEXTURE_MATRIX                           0x009706C0
+#   define NV097_SET_TEXGEN_PLANE_S                           0x00970840
+#   define NV097_SET_TEXGEN_PLANE_T                           0x00970850
+#   define NV097_SET_TEXGEN_PLANE_R                           0x00970860
+#   define NV097_SET_TEXGEN_PLANE_Q                           0x00970870
 #   define NV097_SET_TEXGEN_VIEW_MODEL                        0x009709CC
 #       define NV097_SET_TEXGEN_VIEW_MODEL_LOCAL_VIEWER           0
 #       define NV097_SET_TEXGEN_VIEW_MODEL_INFINITE_VIEWER        1
@@ -1446,14 +1450,15 @@ typedef struct PGRAPHState {
     float composite_matrix[16];
 
     /* FIXME: These are probably stored in the vshader consts */
-    bool texture_matrix_enable[4];
-    float texture_matrix[4][16]; /* 4 stages with 4x4 matrix each */
+    bool texture_matrix_enable[NV2A_MAX_TEXTURES];
+    float texture_matrix[NV2A_MAX_TEXTURES][16]; /* 4 stages with 4x4 matrix each */
+    float texture_plane[NV2A_MAX_TEXTURES][4][4]; /* 4 stages, 4 components + plane for each */
     float projection_matrix[16];
     float inverse_model_view_matrix[4][16]; /* 4 weights with 4x4 matrix each */
     float model_view_matrix[4][16]; /* 4 weights with 4x4 matrix each */
 
     /* FIXME: Move to NV_PGRAPH_BUMPMAT... */
-    float bump_env_matrix[3][4]; /* 4 stages with 2x2 matrix each */
+    float bump_env_matrix[NV2A_MAX_TEXTURES-1][4]; /* 3 allowed stages with 2x2 matrix each */
 
     GloContext *gl_context;
     GLuint gl_framebuffer;
@@ -2874,7 +2879,7 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
     }
 
     /* For each texture stage */
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < NV2A_MAX_TEXTURES; i++) {
         char name[32];
         GLint loc;
 
@@ -2908,6 +2913,16 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
         loc = glGetUniformLocation(pg->shader_binding->gl_program, name);
         if (loc != -1) {
             glUniformMatrix4fv(loc, 1, GL_FALSE, pg->texture_matrix[i]);
+        }
+
+        /* TexGen planes */
+        for(j = 0; j < 4; j++) {
+            char cSuffix = "STRQ"[j];
+            snprintf(name, sizeof(name), "texPlane%c%d", cSuffix, i);
+            loc = glGetUniformLocation(pg->shader_binding->gl_program, name);
+            if (loc != -1) {
+                glUniform4fv(loc, 1, pg->texture_plane[i][j]);
+            }
         }
 
     }
@@ -4239,6 +4254,15 @@ static void pgraph_method(NV2AState *d,
         slot = (class_method - NV097_SET_TEXTURE_MATRIX) / 4;
         pg->texture_matrix[slot / 16][slot % 16] = *(float*)&parameter;
         break;
+
+    /* Handles NV097_SET_TEXGEN_PLANE_S,T,R,Q */
+    case NV097_SET_TEXGEN_PLANE_S ...
+            NV097_SET_TEXGEN_PLANE_S + 0xfc: {
+        slot = (class_method - NV097_SET_TEXGEN_PLANE_S) / 4;
+        unsigned int part = slot % 16;
+        pg->texture_plane[slot / 16][part / 4][part % 4] = *(float*)&parameter;
+        break;
+    }
 
     case NV097_SET_TEXGEN_VIEW_MODEL:
         SET_MASK(pg->regs[NV_PGRAPH_CSV0_D], NV_PGRAPH_CSV0_D_TEXGEN_REF,

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -239,7 +239,7 @@ static QString* generate_fixed_function(const ShaderState state,
     }
 
     /* Texgen */
-    for (i = 0; i < 4 /* NV2A_MAX_TEXTURES */; i++) {
+    for (i = 0; i < 4 /* FIXME: NV2A_MAX_TEXTURES */; i++) {
         qstring_append_fmt(s, "/* Texgen for stage %d */\n",
                            i);
         qstring_append_fmt(s, "vec4 tTexture%d;\n",
@@ -258,21 +258,23 @@ static QString* generate_fixed_function(const ShaderState state,
             case TEXGEN_EYE_LINEAR:
                 qstring_append_fmt(s, "tTexture%d.%c = dot(tTexPlane%c%d, tPosition);\n",
                                    i, c, cSuffix, i);
+assert(false); /* Untested */
                 break;
             case TEXGEN_OBJECT_LINEAR:
                 qstring_append_fmt(s, "tTexture%d.%c = dot(texPlane%c%d, position);\n",
                                    i, c, cSuffix, i);
+assert(false); /* Untested */
                 break;
             case TEXGEN_SPHERE_MAP:
                 assert(i < 2);  /* Channels S,T only! */
                 qstring_append(s, "{\n");
-                /* FIXME: r and m only have to be calculated once */
+                /* FIXME: u, r and m only have to be calculated once */
                 qstring_append(s, "  vec3 u = normalize(tPosition.xyz);\n");
                 //FIXME: tNormal before or after normalization? Always normalize?
                 qstring_append(s, "  vec3 r = reflect(u, tNormal);\n");
 
                 /* FIXME: This would consume 1 division fewer and *might* be
-                 *        faster than `length`:
+                 *        faster than length:
                  *   // [z=1/(2*x) => z=1/x*0.5]
                  *   vec3 ro = r + vec3(0.0, 0.0, 1.0);
                  *   float m = inversesqrt(dot(ro,ro))*0.5;
@@ -282,6 +284,7 @@ static QString* generate_fixed_function(const ShaderState state,
                 qstring_append_fmt(s, "  tTexture%d.%c = r.%c * invM + 0.5;\n",
                                    i, c, c);
                 qstring_append(s, "}\n");
+assert(false); /* Untested */
                 break;
             case TEXGEN_REFLECTION_MAP:
                 assert(i < 3); /* Channels S,T,R only! */


### PR DESCRIPTION
This is mostly untested because a lack of test cases.
TEXGEN_REFLECTION_MAP has been tested and seems to works fine. I don't remember testing TEXGEN_NORMAL_MAP but according to my comments it SHOULD be tested [I wrote this a couple of weeks ago but only rebased and retested now].

Feature wise this should be complete (and hopefully working). However it's only working with the fixed function pipeline so far. Support for vertex programs will follow in another PR (part of this is already done in my shadowbuffer branch by unifying the transforms. A new PR will probably contain code to use the same constant space, foggen and texgen).

Review, test and merge please?
