### PR TITLE
Use uniform buffer objects

### DIFF
--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -593,14 +593,8 @@ ShaderBinding* generate_shaders(const ShaderState state)
             ret->psh_constant_loc[i][j] = glGetUniformLocation(program, tmp);
         }
     }
-    if (state.vertex_program) {
-        /* lookup vertex shader bindings */
-        for(i = 0; i < NV2A_VERTEXSHADER_CONSTANTS; i++) {
-            char tmp[8];
-            snprintf(tmp, sizeof(tmp), "c[%d]", i);
-            ret->vsh_constant_loc[i] = glGetUniformLocation(program, tmp);
-        }
-    }
+
+    ret->gl_constants_loc = glGetUniformBlockIndex(program, "VertexConstants");
 
     return ret;
 }

--- a/hw/xbox/nv2a_shaders.h
+++ b/hw/xbox/nv2a_shaders.h
@@ -87,7 +87,7 @@ typedef struct ShaderState {
 typedef struct ShaderBinding {
     GLuint gl_program;
     GLint psh_constant_loc[9][2];
-    GLint vsh_constant_loc[NV2A_VERTEXSHADER_CONSTANTS];
+    GLint gl_constants_loc;
 } ShaderBinding;
 
 ShaderBinding* generate_shaders(const ShaderState state);

--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -567,7 +567,9 @@ static const char* vsh_header =
 
 
     /* All constants in 1 array declaration */
-   "uniform vec4 c[192];\n"
+   "layout(shared) uniform VertexConstants {\n"
+   "  uniform vec4 c[192];\n"
+   "};"
    "\n"
    "uniform vec2 clipRange;\n"
    "uniform vec2 surfaceSize;\n"


### PR DESCRIPTION
Ran DoA3 - still worked.
Didn't test much further. This should save us a ton of uniform uploads.
We should probably have copies of the buffer so GL doesn't stall when changing it.

Review please?
(never worked with UBOs before, so I'm using this PR so others can review)
