### PR TITLE
DSP: and #xx, D + hotfix for fog

### DIFF
--- a/hw/xbox/dsp/dsp_cpu.c
+++ b/hw/xbox/dsp/dsp_cpu.c
@@ -162,7 +162,7 @@ static bool match_MMMRRR(uint32_t op)
 static const OpcodeEntry nonparallel_opcodes[] = {
     { "0000000101iiiiii1000d000", "add #xx, D", dis_add_imm, emu_add_imm },
     { "00000001010000001100d000", "add #xxxx, D", dis_add_long, emu_add_long },
-    { "0000000101iiiiii1000d110", "and #xx, D", NULL, NULL },
+    { "0000000101iiiiii1000d110", "and #xx, D", dis_and_imm, emu_and_imm },
     { "00000001010000001100d110", "and #xxxx, D", dis_and_long, emu_and_long },
     { "00000000iiiiiiii101110EE", "andi #xx, D", dis_andi, emu_andi },
     { "0000110000011101SiiiiiiD", "asl #ii, S2, D", dis_asl_imm, emu_asl_imm },

--- a/hw/xbox/dsp/dsp_dis.inl
+++ b/hw/xbox/dsp/dsp_dis.inl
@@ -258,6 +258,13 @@ static void dis_add_long(dsp_core_t* dsp)
     sprintf(dsp->disasm_str_instr, "add #$%04x,%s", xxxx, registers_name[accname]);
 }
 
+static void dis_and_imm(dsp_core_t* dsp)
+{
+    uint32_t xx = (dsp->disasm_cur_inst >> 8) & BITMASK(6);
+    uint32_t accname = ((dsp->disasm_cur_inst >> 3) & 1) ? DSP_REG_B : DSP_REG_A;
+    sprintf(dsp->disasm_str_instr, "and #$%02x,%s", xx, registers_name[accname]);
+}
+
 static void dis_and_long(dsp_core_t* dsp)
 {
     dsp->disasm_cur_inst_len++;

--- a/hw/xbox/dsp/dsp_emu.inl
+++ b/hw/xbox/dsp/dsp_emu.inl
@@ -5809,7 +5809,7 @@ static void emu_add_x(dsp_core_t* dsp, uint32_t x, uint32_t d)
 
     uint16_t newsr = dsp_add56(source, dest);
 
-    if ((dsp->cur_inst >> 3) & 1) {
+    if (d) {
         dsp->registers[DSP_REG_B2] = dest[0];
         dsp->registers[DSP_REG_B1] = dest[1];
         dsp->registers[DSP_REG_B0] = dest[2];
@@ -5840,23 +5840,35 @@ static void emu_add_long(dsp_core_t* dsp)
     emu_add_x(dsp, xxxx, d);
 }
 
-static void emu_and_long(dsp_core_t* dsp)
+static void emu_and_x(dsp_core_t* dsp, uint32_t x, uint32_t d)
 {
-    uint32_t xxxx = read_memory_p(dsp, dsp->pc+1);
-    dsp->cur_inst_len++;
-
     int dstreg;
-    if ((dsp->cur_inst >> 3) & 1) {
+    if (d) {
         dstreg = DSP_REG_B1;
     } else {
         dstreg = DSP_REG_A1;
     }
 
-    dsp->registers[dstreg] &= xxxx;
+    dsp->registers[dstreg] &= x;
 
     dsp->registers[DSP_REG_SR] &= BITMASK(16)-((1<<DSP_SR_N)|(1<<DSP_SR_Z)|(1<<DSP_SR_V));
     dsp->registers[DSP_REG_SR] |= ((dsp->registers[dstreg]>>23) & 1)<<DSP_SR_N;
     dsp->registers[DSP_REG_SR] |= (dsp->registers[dstreg]==0)<<DSP_SR_Z;
+}
+
+static void emu_and_imm(dsp_core_t* dsp)
+{
+    uint32_t xx = (dsp->cur_inst >> 8) & BITMASK(6);
+    uint32_t d = (dsp->cur_inst >> 3) & 1;
+    emu_and_x(dsp, xx, d);
+}
+
+static void emu_and_long(dsp_core_t* dsp)
+{
+    uint32_t xxxx = read_memory_p(dsp, dsp->pc+1);
+    dsp->cur_inst_len++;
+    uint32_t d = (dsp->cur_inst >> 3) & 1;
+    emu_and_x(dsp, xxxx, d);
 }
 
 static void emu_andi(dsp_core_t* dsp)

--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -746,6 +746,7 @@ QString* vsh_translate(uint16_t version,
     qstring_append(header, vsh_header);
 
     QString *body = qstring_from_str("\n");
+    qstring_append(body,"  oFog.x = 1.0;\n"); /* FIXME: Use foggen? */
 
     bool has_final = false;
     int slot;


### PR DESCRIPTION
This fixes 'Breakdown'

It was missing a DSP instruction.
Also the intros (and possibly menu) were entirely covered in fog. I fixed it by adding a hack to the VSH code. It's probably better than what we have know.
I'll try to figure out how foggen/fog works with vertex programs soon and create a seperate branch for work on that. In the meantime this hack will prevent users from thinking games don't render anything.

The game is still VERY slow and asserts after about 20 minutes of menu on my machine with multiple data uploads per BEGIN_END [which will be handled seperately].

Review and merge please.
