### PR TITLE
Unify VP/FFP and fog for VP

### DIFF
--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -527,15 +527,8 @@ static void generate_fixed_function(const ShaderState state,
         /* From: https://www.opengl.org/registry/specs/NV/fog_distance.txt */
         switch(state.foggen) {
         case FOGGEN_SPEC_ALPHA:
-            assert(false); /* FIXME: Do this before or after calculations in VSH? */
-            if (state.fixed_function) {
-                /* FIXME: Do we have to clamp here? */
-                qstring_append(body, "  float fogDistance = clamp(specular.a, 0.0, 1.0);\n");
-            } else if (state.vertex_program) {
-                qstring_append(body, "  float fogDistance = oD1.a;\n");
-            } else {
-                assert(false);
-            }
+            /* FIXME: Do we have to clamp here? */
+            qstring_append(body, "  float fogDistance = clamp(specular.a, 0.0, 1.0);\n");
             break;
         case FOGGEN_RADIAL:
             qstring_append(body, "  float fogDistance = length(tPosition.xyz)");
@@ -548,13 +541,7 @@ static void generate_fixed_function(const ShaderState state,
             }
             break;
         case FOGGEN_FOG_X:
-            if (state.fixed_function) {
-                qstring_append(body, "  float fogDistance = fogCoord;\n");
-            } else if (state.vertex_program) {
-                qstring_append(body, "  float fogDistance = oFog.x;\n");
-            } else {
-                assert(false);
-            }
+            qstring_append(body, "  float fogDistance = fogCoord;\n");
             break;
         default:
             assert(false);

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -588,7 +588,21 @@ static QString *generate_vertex_shader(const ShaderState state,
                                   "vec4 oB0 = vec4(0.0,0.0,0.0,1.0);\n"
                                   "vec4 oB1 = vec4(0.0,0.0,0.0,1.0);\n"
                                   "vec4 oPts = vec4(0.0,0.0,0.0,1.0);\n"
-                                  "vec4 oFog = vec4(0.0,0.0,0.0,1.0);\n"
+    /* FIXME: NV_vertex_program says: "FOGC is the transformed vertex's fog
+     * coordinate. The register's first floating-point component is interpolated
+     * across the assembled primitive during rasterization and used as the fog
+     * distance to compute per-fragment the fog factor when fog is enabled.
+     * However, if both fog and vertex program mode are enabled, but the FOGC
+     * vertex result register is not written, the fog factor is overridden to
+     * 1.0. The register's other three components are ignored."
+     *
+     * That probably means it will read back as vec4(0.0, 0.0, 0.0, 1.0) but
+     * will be set to 1.0 AFTER the VP if it was never written?
+     * We should test on real hardware..
+     *
+     * We'll force 1.0 for oFog.x for now.
+     */
+                                  "vec4 oFog = vec4(1.0,0.0,0.0,1.0);\n"
                                   "vec4 oT0 = vec4(0.0,0.0,0.0,1.0);\n"
                                   "vec4 oT1 = vec4(0.0,0.0,0.0,1.0);\n"
                                   "vec4 oT2 = vec4(0.0,0.0,0.0,1.0);\n"

--- a/hw/xbox/nv2a_vsh.h
+++ b/hw/xbox/nv2a_vsh.h
@@ -131,10 +131,10 @@ typedef enum {
 
 uint8_t vsh_get_field(const uint32_t *shader_token, VshFieldName field_name);
 
-QString* vsh_translate(uint16_t version,
-                       const uint32_t *tokens,
-                       unsigned int length,
-                       char out_prefix);
+void vsh_translate(uint16_t version,
+                   const uint32_t *tokens,
+                   unsigned int length,
+                   QString *header, QString *body);
 
 
 #endif


### PR DESCRIPTION
This branch attempts to unify VP and FFP so code can be re-used more easily by both pipelines.
I also moved the fog code to the unified part so that it _should_ work in vertex programs now.
However, I'm not sure about how exactly the VP fog works yet so I uploaded this version with some debug printf left.

Cleanup will happen when I made sure this doesn't break anything.

I haven't seen any regressions yet but it fixes RollerCoaster Tycoon.
If you find a game which looks broken [nothing visible / all in one color, fog looks strange, no fog when there is supposed to be fog etc.] feel free to contact me and I'll try to reproduce it.
