### PR TITLE
Avoid multiplying xyz by w=zero

### DIFF
--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -802,7 +802,7 @@ QString* vsh_translate(uint16_t version,
         "}\n"
 
         /* Correct for the perspective divide */
-        "if (oPos.w <= 0.0) {\n"
+        "if (oPos.w < 0.0) {\n"
             /* undo the perspective divide in the case where the point would be
              * clipped so opengl can clip it correctly */
         "  oPos.xyz *= oPos.w;\n"


### PR DESCRIPTION
Kung Fu Chaos has some odd shaders.. They load a variety of constants and multiply them by 0.0 or -0.0.
Long story short it ends up with something like oPos = vec4(v0.xy, -0.0, -0.0). This currently results in oPos.xy *= oPos.w [for the perspective divide undo] which will kill all possible output.

This fixes that.

From black screen to http://imgur.com/a/0wRO4 by removing a single symbol. Yay?!

//Edit: Didn't test this very much. Basicly only ran kung fu chaos with it so far.
