### PR TITLE
Also floor() negative numbers in ARL

### DIFF
--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -664,7 +664,7 @@ static const char* vsh_header =
     "#define ARL(dest, src) dest = _ARL(_in(src).x)\n"
     "int _ARL(float src)\n"
     "{\n"
-    "  return int(src);\n"
+    "  return int(floor(src));\n"
     "}\n"
     "\n"
     "#define SGE(dest, mask, src0, src1) dest.mask = _SGE(_in(src0), _in(src1)).mask\n"


### PR DESCRIPTION
Fixes character select in Kelly Slater Pro Surfer (which does the skinning in software). Otherwise players have broken torso.

[I believed the issue in Tony Hawks Pro Skater 2X (Torso broken after a couple of frames) is related but surprisingly it is not fixed by this. I'll probably have to check their shader and mesh data.]
