### PR TITLE
Support for QUAD_STRIP and POLYGON (Fill and point rendering only)

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1101,9 +1101,9 @@ static const GLenum kelvin_primitive_map[] = {
     GL_TRIANGLES,
     GL_TRIANGLE_STRIP,
     GL_TRIANGLE_FAN,
-    GL_LINES_ADJACENCY, // GL_QUADS,
-    // GL_QUAD_STRIP,
-    // GL_POLYGON,
+    GL_LINES_ADJACENCY, /* QUADS */
+    GL_LINE_STRIP_ADJACENCY, /* QUAD_STRIP */
+    GL_TRIANGLE_FAN /* POLYGON */
 };
 
 static const GLenum pgraph_texture_min_filter_map[] = {
@@ -5329,6 +5329,15 @@ static void pgraph_method(NV2AState *d,
             assert(front_mode < ARRAYSIZE(pgraph_polygon_mode_map));
             glPolygonMode(GL_FRONT_AND_BACK,
                           pgraph_polygon_mode_map[front_mode]);
+            /* FIXME: Line rendering for POLYGON can be done using line loop,
+             *        QUADS and QUAD_STRIP need a geometry shader. Also what
+             *        about the interpolation / provoking vertex for flat
+             *        shaded points / lines?
+             */
+            assert(!((pg->primitive_mode == PRIM_TYPE_QUADS ||
+                      pg->primitive_mode == PRIM_TYPE_QUAD_STRIP ||
+                      pg->primitive_mode == PRIM_TYPE_POLYGON) &&
+                     front_mode == NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_LINE));
 
             /* Polygon offset */
             /* FIXME: GL implementation-specific, maybe do this in VS? */

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -39,6 +39,7 @@ static QString* generate_geometry_shader(enum ShaderPrimitiveMode primitive_mode
     qstring_append(s, "\n");
     switch (primitive_mode) {
     case PRIM_TYPE_QUADS:
+    case PRIM_TYPE_QUAD_STRIP:
         qstring_append(s, "layout(lines_adjacency) in;\n");
         qstring_append(s, "layout(triangle_strip, max_vertices = 4) out;\n");
         break;
@@ -62,6 +63,15 @@ static QString* generate_geometry_shader(enum ShaderPrimitiveMode primitive_mode
         generate_geometry_shader_pass_vertex(s, "3");
         generate_geometry_shader_pass_vertex(s, "2");
         qstring_append(s, "EndPrimitive();\n");
+        break;
+    case PRIM_TYPE_QUAD_STRIP:
+        qstring_append(s, "if ((gl_PrimitiveIDIn & 1) == 0) {\n");
+        generate_geometry_shader_pass_vertex(s, "0");
+        generate_geometry_shader_pass_vertex(s, "1");
+        generate_geometry_shader_pass_vertex(s, "2");
+        generate_geometry_shader_pass_vertex(s, "3");
+        qstring_append(s, "  EndPrimitive();\n"
+                          "}");
         break;
     default:
         assert(false);
@@ -593,7 +603,8 @@ ShaderBinding* generate_shaders(const ShaderState state)
 {
     int i, j;
 
-    bool with_geom = state.primitive_mode == PRIM_TYPE_QUADS;
+    bool with_geom = state.primitive_mode == PRIM_TYPE_QUADS ||
+                     state.primitive_mode == PRIM_TYPE_QUAD_STRIP;
     char vtx_prefix = with_geom ? 'v' : 'g';
 
     GLuint program = glCreateProgram();


### PR DESCRIPTION
What the title says.

I don't have any games using QUAD_STRIPS this at the moment but did unit tests.
Also GL spec [according to this (German)](http://wiki.delphigl.com/index.php/glBegin) says you can use TRI_FANs for POLYGON.

I added an assertion for wireframe rendering these types, I have [a WIP branch for line rendering support](https://github.com/JayFoxRox/xqemu/tree/prim-modes-line) ~~but I'm too lazy to continue on it~~ which is still WIP, so this'll do for now - it's probably never used anyway.

Hopefully fixes:
- America's Army: Rise of a Soldier
- Army Men: Major Malfunction
- Doom 3
- Forza Motorsport
- Genma Onimusha
- Hitman: Contracts
- Knight's Apprentice: Memorick's Adventures
- Knockout Kings 2002
- Lotus Challenge
- Magic the Gathering: Battlegrounds
- Mortal Kombat: Deception
- OutRun 2
- OutRun 2006: Coast 2 Coast
- Phantom Dust
- Pirates: Legend of the Black Buccaneer
- Samurai Warriors
- Scarface: The World Is Yours
- Sega GT 2002
- Shin Megami Tensei: NINE[JP]
- Stake: Fortune Fighters

(List probably incomplete but also might run into new issues. If there are graphical issues now but they didn't work before I probably got my vertex order wrong)

Test please? Provide screenshots (and game name..) in case of bad geometry if this doesn't work.
