### PR TITLE
XID update

### DIFF
--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -297,16 +297,27 @@ static void usb_xid_handle_control(USBDevice *dev, USBPacket *p,
         break;
     case VendorInterfaceRequest | XID_GET_CAPABILITIES:
         DPRINTF("xid XID_GET_CAPABILITIES 0x%x\n", value);
-        //FIXME: !
+        /* FIXME: ! */
         p->status = USB_RET_STALL;
         //assert(false);
         break;
-    case ((USB_DIR_IN|USB_TYPE_CLASS|USB_RECIP_DEVICE)<<8) | 0x06:
-        DPRINTF("xid unknown xpad request 1: value = 0x%x\n", value);
+    case ((USB_DIR_IN|USB_TYPE_CLASS|USB_RECIP_DEVICE)<<8)
+             | USB_REQ_GET_DESCRIPTOR:
+        /* FIXME: ! */
+        DPRINTF("xid unknown xpad request 0x%x: value = 0x%x\n",
+                request, value);
         memset(data, 0x00, length);
         //FIXME: Intended for the hub: usbd_get_hub_descriptor, UT_READ_CLASS?!
         p->status = USB_RET_STALL;
         //assert(false);
+        break;
+    case ((USB_DIR_OUT|USB_TYPE_STANDARD|USB_RECIP_ENDPOINT)<<8)
+             | USB_REQ_CLEAR_FEATURE:
+        /* FIXME: ! */
+        DPRINTF("xid unknown xpad request 0x%x: value = 0x%x\n",
+                request, value);
+        memset(data, 0x00, length);
+        p->status = USB_RET_STALL;
         break;
     default:
         DPRINTF("xid USB stalled on request 0x%x value 0x%x\n", request, value);

--- a/hw/xbox/xid.c
+++ b/hw/xbox/xid.c
@@ -168,6 +168,11 @@ static const XIDDesc desc_xid_xbox_gamepad = {
 #define GAMEPAD_LEFT_THUMB_LEFT  18
 #define GAMEPAD_LEFT_THUMB_RIGHT 19
 
+#define GAMEPAD_RIGHT_THUMB_UP    20
+#define GAMEPAD_RIGHT_THUMB_DOWN  21
+#define GAMEPAD_RIGHT_THUMB_LEFT  22
+#define GAMEPAD_RIGHT_THUMB_RIGHT 23
+
 static const int gamepad_mapping[] = {
     [0 ... Q_KEY_CODE_MAX] = -1,
 
@@ -183,17 +188,27 @@ static const int gamepad_mapping[] = {
     [Q_KEY_CODE_RET]   = GAMEPAD_START,
     [Q_KEY_CODE_BACKSPACE] = GAMEPAD_BACK,
 
-    [Q_KEY_CODE_Z]     = GAMEPAD_A,
-    [Q_KEY_CODE_X]     = GAMEPAD_B,
-    [Q_KEY_CODE_A]     = GAMEPAD_X,
-    [Q_KEY_CODE_S]     = GAMEPAD_Y,
-    [Q_KEY_CODE_Q]     = GAMEPAD_LEFT_TRIGGER,
-    [Q_KEY_CODE_W]     = GAMEPAD_RIGHT_TRIGGER,
+    [Q_KEY_CODE_W]     = GAMEPAD_X,
+    [Q_KEY_CODE_E]     = GAMEPAD_Y,
+    [Q_KEY_CODE_S]     = GAMEPAD_A,
+    [Q_KEY_CODE_D]     = GAMEPAD_B,
+    [Q_KEY_CODE_X]     = GAMEPAD_WHITE,
+    [Q_KEY_CODE_C]     = GAMEPAD_BLACK,
 
-    [Q_KEY_CODE_U]     = GAMEPAD_LEFT_THUMB_UP,
-    [Q_KEY_CODE_J]     = GAMEPAD_LEFT_THUMB_DOWN,
-    [Q_KEY_CODE_H]     = GAMEPAD_LEFT_THUMB_LEFT,
-    [Q_KEY_CODE_K]     = GAMEPAD_LEFT_THUMB_RIGHT,
+    [Q_KEY_CODE_Q]     = GAMEPAD_LEFT_TRIGGER,
+    [Q_KEY_CODE_R]     = GAMEPAD_RIGHT_TRIGGER,
+
+    [Q_KEY_CODE_V]     = GAMEPAD_LEFT_THUMB,
+    [Q_KEY_CODE_T]     = GAMEPAD_LEFT_THUMB_UP,
+    [Q_KEY_CODE_F]     = GAMEPAD_LEFT_THUMB_LEFT,
+    [Q_KEY_CODE_G]     = GAMEPAD_LEFT_THUMB_DOWN,
+    [Q_KEY_CODE_H]     = GAMEPAD_LEFT_THUMB_RIGHT,
+
+    [Q_KEY_CODE_M]     = GAMEPAD_RIGHT_THUMB,
+    [Q_KEY_CODE_I]     = GAMEPAD_RIGHT_THUMB_UP,
+    [Q_KEY_CODE_J]     = GAMEPAD_RIGHT_THUMB_LEFT,
+    [Q_KEY_CODE_K]     = GAMEPAD_RIGHT_THUMB_DOWN,
+    [Q_KEY_CODE_L]     = GAMEPAD_RIGHT_THUMB_RIGHT,
 };
 
 static void xbox_gamepad_keyboard_event(void *opaque, int keycode)
@@ -230,6 +245,19 @@ static void xbox_gamepad_keyboard_event(void *opaque, int keycode)
         break;
     case GAMEPAD_LEFT_THUMB_RIGHT:
         s->in_state.sThumbLX = up?0:32767;
+        break;
+
+    case GAMEPAD_RIGHT_THUMB_UP:
+        s->in_state.sThumbRY = up?0:32767;
+        break;
+    case GAMEPAD_RIGHT_THUMB_DOWN:
+        s->in_state.sThumbRY = up?0:-32768;
+        break;
+    case GAMEPAD_RIGHT_THUMB_LEFT:
+        s->in_state.sThumbRX = up?0:-32768;
+        break;
+    case GAMEPAD_RIGHT_THUMB_RIGHT:
+        s->in_state.sThumbRX = up?0:32767;
         break;
     default:
         break;


### PR DESCRIPTION
Remapped XID. I tried to avoid Z/Y (because it's probably the most common keyboard layout difference) and mapped all input options a default controller has to offer.
The face buttons are placed similar to the Controller S. I had to move A,B,X,Y [= S,D,W,E] up a little to fit black and white [= X and C].
I use T,F,G,H for the left stick and V [which should be the row below on most keyboards] to press the button down.
Same thing for the right stick I,J,K,L and M to press it.
I decided to use Q and R for the triggers [left and right of the face buttons]

Included is also one more USB packet which should fix some games [or might disable input randomly once the packet occurs]
