### PR TITLE
Implement polygon modes in geometry shader

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1101,9 +1101,9 @@ static const GLenum kelvin_primitive_map[] = {
     GL_TRIANGLES,
     GL_TRIANGLE_STRIP,
     GL_TRIANGLE_FAN,
-    GL_LINES_ADJACENCY, // GL_QUADS,
-    // GL_QUAD_STRIP,
-    // GL_POLYGON,
+    GL_LINES_ADJACENCY, /* QUADS */
+    GL_LINE_STRIP_ADJACENCY, /* QUAD_STRIP */
+    GL_TRIANGLE_FAN /* POLYGON */
 };
 
 static const GLenum pgraph_texture_min_filter_map[] = {
@@ -5329,6 +5329,15 @@ static void pgraph_method(NV2AState *d,
             assert(front_mode < ARRAYSIZE(pgraph_polygon_mode_map));
             glPolygonMode(GL_FRONT_AND_BACK,
                           pgraph_polygon_mode_map[front_mode]);
+            /* FIXME: Line rendering for POLYGON can be done using line loop,
+             *        QUADS and QUAD_STRIP need a geometry shader. Also what
+             *        about the interpolation / provoking vertex for flat
+             *        shaded points / lines?
+             */
+            assert(!((pg->primitive_mode == PRIM_TYPE_QUADS ||
+                      pg->primitive_mode == PRIM_TYPE_QUAD_STRIP ||
+                      pg->primitive_mode == PRIM_TYPE_POLYGON) &&
+                     front_mode == NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_LINE));
 
             /* Polygon offset */
             /* FIXME: GL implementation-specific, maybe do this in VS? */

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1091,21 +1091,6 @@
 #   define NV097_SET_TRANSFORM_PROGRAM_START                  0x00971EA0
 #   define NV097_SET_TRANSFORM_CONSTANT_LOAD                  0x00971EA4
 
-
-static const GLenum kelvin_primitive_map[] = {
-    0,
-    GL_POINTS,
-    GL_LINES,
-    GL_LINE_LOOP,
-    GL_LINE_STRIP,
-    GL_TRIANGLES,
-    GL_TRIANGLE_STRIP,
-    GL_TRIANGLE_FAN,
-    GL_LINES_ADJACENCY, /* QUADS */
-    GL_LINE_STRIP_ADJACENCY, /* QUAD_STRIP */
-    GL_TRIANGLE_FAN /* POLYGON */
-};
-
 static const GLenum pgraph_texture_min_filter_map[] = {
     0,
     GL_NEAREST,
@@ -1187,12 +1172,6 @@ static const GLenum pgraph_cull_face_map[] = {
     GL_FRONT,
     GL_BACK,
     GL_FRONT_AND_BACK
-};
-
-static const GLenum pgraph_polygon_mode_map[] = {
-    GL_FILL,
-    GL_POINT,
-    GL_LINE
 };
 
 static const GLenum pgraph_depth_func_map[] = {
@@ -1636,7 +1615,6 @@ typedef struct PGRAPHState {
     hwaddr dma_vertex_a, dma_vertex_b;
 
     unsigned int primitive_mode;
-    GLenum gl_primitive_mode;
 
     bool enable_vertex_program_write;
 
@@ -2969,6 +2947,10 @@ static void pgraph_bind_shaders(PGRAPHState *pg)
 
         /* geometry shader stuff */
         .primitive_mode = pg->primitive_mode,
+        .polygon_front_mode = GET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
+                                       NV_PGRAPH_SETUPRASTER_FRONTFACEMODE),
+        .polygon_back_mode = GET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
+                                      NV_PGRAPH_SETUPRASTER_BACKFACEMODE),
     };
 
     state.program_length = 0;
@@ -5155,6 +5137,8 @@ static void pgraph_method(NV2AState *d,
 
         if (parameter == NV097_SET_BEGIN_END_OP_END) {
 
+            assert(pg->shader_binding);
+
             if (pg->draw_arrays_length) {
 
                 NV2A_GL_DPRINTF(false, "Draw Arrays");
@@ -5165,7 +5149,7 @@ static void pgraph_method(NV2AState *d,
 
                 pgraph_bind_vertex_attributes(d, pg->draw_arrays_max_count,
                                               false, 0);
-                glMultiDrawArrays(pg->gl_primitive_mode,
+                glMultiDrawArrays(pg->shader_binding->gl_primitive_mode,
                                   pg->gl_draw_arrays_start,
                                   pg->gl_draw_arrays_count,
                                   pg->draw_arrays_length);
@@ -5204,7 +5188,7 @@ static void pgraph_method(NV2AState *d,
 
                 }
 
-                glDrawArrays(pg->gl_primitive_mode,
+                glDrawArrays(pg->shader_binding->gl_primitive_mode,
                              0, pg->inline_buffer_length);
             } else if (pg->inline_array_length) {
 
@@ -5215,7 +5199,8 @@ static void pgraph_method(NV2AState *d,
                 assert(pg->inline_elements_length == 0);
 
                 unsigned int index_count = pgraph_bind_inline_array(d);
-                glDrawArrays(pg->gl_primitive_mode, 0, index_count);
+                glDrawArrays(pg->shader_binding->gl_primitive_mode,
+                             0, index_count);
             } else if (pg->inline_elements_length) {
 
                 NV2A_GL_DPRINTF(false, "Inline Elements");
@@ -5239,7 +5224,7 @@ static void pgraph_method(NV2AState *d,
                              pg->inline_elements,
                              GL_DYNAMIC_DRAW);
 
-                glDrawRangeElements(pg->gl_primitive_mode,
+                glDrawRangeElements(pg->shader_binding->gl_primitive_mode,
                                     min_element, max_element,
                                     pg->inline_elements_length,
                                     GL_UNSIGNED_INT,
@@ -5262,9 +5247,7 @@ static void pgraph_method(NV2AState *d,
 
             pgraph_update_surface(d, true, true, depth_test || stencil_test);
 
-            assert(parameter < ARRAYSIZE(kelvin_primitive_map));
             pg->primitive_mode = parameter;
-            pg->gl_primitive_mode = kelvin_primitive_map[parameter];
 
             uint32_t control_0 = pg->regs[NV_PGRAPH_CONTROL_0];
 
@@ -5318,26 +5301,6 @@ static void pgraph_method(NV2AState *d,
             glFrontFace(pg->regs[NV_PGRAPH_SETUPRASTER]
                             & NV_PGRAPH_SETUPRASTER_FRONTFACE
                                 ? GL_CCW : GL_CW);
-
-            /* Polygon mode */
-            uint32_t front_mode = GET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
-                                           NV_PGRAPH_SETUPRASTER_FRONTFACEMODE);
-            uint32_t back_mode =  GET_MASK(pg->regs[NV_PGRAPH_SETUPRASTER],
-                                           NV_PGRAPH_SETUPRASTER_BACKFACEMODE);
-            /* FIXME: GL3+ only supports GL_FRONT_AND_BACK, how to handle? */
-            assert(front_mode == back_mode);
-            assert(front_mode < ARRAYSIZE(pgraph_polygon_mode_map));
-            glPolygonMode(GL_FRONT_AND_BACK,
-                          pgraph_polygon_mode_map[front_mode]);
-            /* FIXME: Line rendering for POLYGON can be done using line loop,
-             *        QUADS and QUAD_STRIP need a geometry shader. Also what
-             *        about the interpolation / provoking vertex for flat
-             *        shaded points / lines?
-             */
-            assert(!((pg->primitive_mode == PRIM_TYPE_QUADS ||
-                      pg->primitive_mode == PRIM_TYPE_QUAD_STRIP ||
-                      pg->primitive_mode == PRIM_TYPE_POLYGON) &&
-                     front_mode == NV_PGRAPH_SETUPRASTER_FRONTFACEMODE_LINE));
 
             /* Polygon offset */
             /* FIXME: GL implementation-specific, maybe do this in VS? */

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -39,6 +39,7 @@ static QString* generate_geometry_shader(enum ShaderPrimitiveMode primitive_mode
     qstring_append(s, "\n");
     switch (primitive_mode) {
     case PRIM_TYPE_QUADS:
+    case PRIM_TYPE_QUAD_STRIP:
         qstring_append(s, "layout(lines_adjacency) in;\n");
         qstring_append(s, "layout(triangle_strip, max_vertices = 4) out;\n");
         break;
@@ -62,6 +63,15 @@ static QString* generate_geometry_shader(enum ShaderPrimitiveMode primitive_mode
         generate_geometry_shader_pass_vertex(s, "3");
         generate_geometry_shader_pass_vertex(s, "2");
         qstring_append(s, "EndPrimitive();\n");
+        break;
+    case PRIM_TYPE_QUAD_STRIP:
+        qstring_append(s, "if ((gl_PrimitiveIDIn & 1) == 0) {\n");
+        generate_geometry_shader_pass_vertex(s, "0");
+        generate_geometry_shader_pass_vertex(s, "1");
+        generate_geometry_shader_pass_vertex(s, "2");
+        generate_geometry_shader_pass_vertex(s, "3");
+        qstring_append(s, "  EndPrimitive();\n"
+                          "}");
         break;
     default:
         assert(false);
@@ -593,7 +603,8 @@ ShaderBinding* generate_shaders(const ShaderState state)
 {
     int i, j;
 
-    bool with_geom = state.primitive_mode == PRIM_TYPE_QUADS;
+    bool with_geom = state.primitive_mode == PRIM_TYPE_QUADS ||
+                     state.primitive_mode == PRIM_TYPE_QUAD_STRIP;
     char vtx_prefix = with_geom ? 'v' : 'g';
 
     GLuint program = glCreateProgram();

--- a/hw/xbox/nv2a_shaders.h
+++ b/hw/xbox/nv2a_shaders.h
@@ -45,6 +45,12 @@ enum ShaderPrimitiveMode {
     PRIM_TYPE_POLYGON,
 };
 
+enum ShaderPolygonMode {
+    POLY_MODE_FILL,
+    POLY_MODE_POINT,
+    POLY_MODE_LINE,
+};
+
 typedef struct ShaderState {
     /* fragment shader - register combiner stuff */
     uint32_t combiner_control;
@@ -85,11 +91,14 @@ typedef struct ShaderState {
     int program_length;
 
     /* primitive format for geometry shader */
+    enum ShaderPolygonMode polygon_front_mode;
+    enum ShaderPolygonMode polygon_back_mode;
     enum ShaderPrimitiveMode primitive_mode;
 } ShaderState;
 
 typedef struct ShaderBinding {
     GLuint gl_program;
+    GLenum gl_primitive_mode;
     GLint psh_constant_loc[9][2];
     GLint gl_constants_loc;
 } ShaderBinding;


### PR DESCRIPTION
Replaces https://github.com/espes/xqemu/pull/58

This prepares us for doing most oldschool rendering specific tasks in shaders:
First I added QUAD_STRIP and POLYGON modes which should work in all polygon modes [POINT, LINE, FILL].
I then refactored and extend it to keep all polygon mode and primitive mode related stuff in a single function.
It should prepare us for two-sided-polygon modes and it will remove any ambiguity with primitive modes and geometry shaders.
Furthermore I decided to stop inlining the common GLSL code in the C portion of the code. GLSL has a good rules about constants and the GPU driver is free to inline the functions itself.

I unit-tested every TRIANGLE\* and QUAD\* primitive type in LINE and FILL mode and ran some games. I haven't come accross any problems yet.
Polygon winding might be wrong so I'll check that again.

(I plan to write a blog post about my experience with recreating those old GL features in the GS to make things a little clearer)

tl;dr: All draw-calls will go through the same shader generation function now. We should have support for all primitive types [except for patches!] in every supported polygon mode.
