### PR TITLE
Increase NV2A_MAX_BATCH_LENGTH to 131071

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1347,7 +1347,7 @@ static const SurfaceColorFormatInfo kelvin_surface_color_format_map[] = {
 #define NV2A_NUM_CHANNELS 32
 #define NV2A_NUM_SUBCHANNELS 8
 
-#define NV2A_MAX_BATCH_LENGTH 0xFFFF
+#define NV2A_MAX_BATCH_LENGTH 0x1FFFF
 #define NV2A_VERTEXSHADER_ATTRIBUTES 16
 #define NV2A_MAX_TEXTURES 4
 


### PR DESCRIPTION
This should be good to merge. I added a very basic unit test above line 5531 in nv2a.c:

if (pg->inline_elements_length > 65536) { printf("value is %d",pg->inline_elements_length); }

Looks like the value gets to around 80,070 in Aeon Flux.  In testing other games as well, I have seen no regression with increasing this value.

This quick patch should allow other games that only reach the intro to go in game.
