### PR TITLE
Timer fixes

### DIFF
--- a/hw/acpi/Makefile.objs
+++ b/hw/acpi/Makefile.objs
@@ -1,2 +1,2 @@
-common-obj-$(CONFIG_ACPI) += core.o piix4.o ich9.o
+obj-$(CONFIG_ACPI) += core.o piix4.o ich9.o
 

--- a/hw/acpi/core.c
+++ b/hw/acpi/core.c
@@ -482,13 +482,21 @@ void acpi_pm_tmr_update(ACPIREGS *ar, bool enable)
 void acpi_pm_tmr_calc_overflow_time(ACPIREGS *ar)
 {
     int64_t d = acpi_pm_tmr_get_clock();
+#ifdef TARGET_XBOX
+    ar->tmr.overflow_time = (d + 0x80000000LL) & ~0x7fffffffLL;
+#else
     ar->tmr.overflow_time = (d + 0x800000LL) & ~0x7fffffLL;
+#endif
 }
 
 static uint32_t acpi_pm_tmr_get(ACPIREGS *ar)
 {
     uint32_t d = acpi_pm_tmr_get_clock();
+#ifdef TARGET_XBOX
+    return d & 0xffffffff;
+#else
     return d & 0xffffff;
+#endif
 }
 
 static void acpi_pm_tmr_timer(void *opaque)

--- a/hw/i386/acpi-build.c
+++ b/hw/i386/acpi-build.c
@@ -492,6 +492,9 @@ static void fadt_setup(AcpiFadtDescriptorRev1 *fadt, AcpiPmInfo *pm)
                               (1 << ACPI_FADT_F_SLP_BUTTON) |
                               (1 << ACPI_FADT_F_RTC_S4));
     fadt->flags |= cpu_to_le32(1 << ACPI_FADT_F_USE_PLATFORM_CLOCK);
+#ifdef TARGET_XBOX
+    fadt->flags |= cpu_to_le32(1 << ACPI_FADT_F_TMR_VAL_EXT);
+#endif
 }
 
 

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -144,7 +144,12 @@ static uint64_t ioportF0_read(void *opaque, hwaddr addr, unsigned size)
 /* TSC handling */
 uint64_t cpu_get_tsc(CPUX86State *env)
 {
+#ifdef TARGET_XBOX
+    return muldiv64(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL), 733333333,
+                    get_ticks_per_sec());
+#else
     return cpu_get_ticks();
+#endif
 }
 
 /* SMM support */

--- a/include/hw/acpi/acpi.h
+++ b/include/hw/acpi/acpi.h
@@ -34,7 +34,11 @@
 #define ACPI_PM_TIMER_WIDTH             32
 
 /* PM Timer ticks per second (HZ) */
+#ifdef TARGET_XBOX
+#define PM_TIMER_FREQUENCY  3375000
+#else
 #define PM_TIMER_FREQUENCY  3579545
+#endif
 
 
 /* ACPI fixed hardware registers */


### PR DESCRIPTION
Xbox titles have several timers to choose from and this PR addresses issues I was seeing with some performance timers.

For basic timer testing I built a [simple test app](https://github.com/mborgerson/xbtests/blob/master/timers/main.c) that samples some different timers and compares them. On real Xbox hardware, the timers will all be within 1ms of each other.

After applying this PR, two of the three time sources tested with this app will be equivalent. The third, which is based on KeTickCount will run a little slower--this counter is incremented on an interrupt from the PIT on a 1ms interval. I tried to fix the PIT but was getting weird results so I left it off this PR.
