### PR TITLE
Avoid switch-cases where default is silent assert

### DIFF
--- a/hw/xbox/dsp/dsp_dma.c
+++ b/hw/xbox/dsp/dsp_dma.c
@@ -96,6 +96,7 @@ static void dsp_dma_run(DSPDMAState *s)
             item_mask = 0x00FFFFFF;
             break;
         default:
+            fprintf(stderr, "Unknown dsp dma format: 0x%x\n", format);
             assert(false);
             break;
         }

--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -2817,7 +2817,9 @@ static void pgraph_method(NV2AState *d,
                 bytes_per_pixel = 4;
                 break;
             default:
+                fprintf(stderr, "Unknown blit surface format: 0x%x\n", context_surfaces->color_format);
                 assert(false);
+                break;
             }
 
             hwaddr source_dma_len, dest_dma_len;
@@ -3220,6 +3222,7 @@ static void pgraph_method(NV2AState *d,
         case NV097_SET_BLEND_FUNC_SFACTOR_V_ONE_MINUS_CONSTANT_ALPHA:
             factor = NV_PGRAPH_BLEND_SFACTOR_ONE_MINUS_CONSTANT_ALPHA; break;
         default:
+            fprintf(stderr, "Unknown blend source factor: 0x%x\n", parameter);
             assert(false);
             break;
         }
@@ -3262,6 +3265,7 @@ static void pgraph_method(NV2AState *d,
         case NV097_SET_BLEND_FUNC_DFACTOR_V_ONE_MINUS_CONSTANT_ALPHA:
             factor = NV_PGRAPH_BLEND_DFACTOR_ONE_MINUS_CONSTANT_ALPHA; break;
         default:
+            fprintf(stderr, "Unknown blend destination factor: 0x%x\n", parameter);
             assert(false);
             break;
         }
@@ -3408,6 +3412,7 @@ static void pgraph_method(NV2AState *d,
         case NV097_SET_FRONT_FACE_V_CCW:
             ccw = true; break;
         default:
+            fprintf(stderr, "Unknown front face: 0x%x\n", parameter);
             assert(false);
             break;
         }
@@ -3842,6 +3847,7 @@ static void pgraph_method(NV2AState *d,
             vertex_attribute->converted_count = 3 * vertex_attribute->count;
             break;
         default:
+            fprintf(stderr, "Unknown vertex type: 0x%x\n", vertex_attribute->format);
             assert(false);
             break;
         }
@@ -4553,6 +4559,7 @@ static void pgraph_method(NV2AState *d,
                 break;
             }
             default:
+                fprintf(stderr, "Unknown zeta surface format: 0x%x\n", pg->surface_shape.zeta_format);
                 assert(false);
                 break;
             }

--- a/hw/xbox/nv2a_vsh.c
+++ b/hw/xbox/nv2a_vsh.c
@@ -363,8 +363,9 @@ static QString* decode_opcode_input(const uint32_t *shader_token,
         }
         break;
     default:
-        printf("Param: 0x%x\n", param);
+        fprintf(stderr, "Unknown vs param: 0x%x\n", param);
         assert(false);
+        break;
     }
     qstring_append(ret_str, tmp);
 


### PR DESCRIPTION
This PR splits the pixel shader texturemode `default:` `assert` into the known unimplemented cases.
This way we'll know which feature is broken by the assert location + we can also see which features we haven't done yet.

For other cases pcmaker has reported as problematic, I've added more explicit stderr-messages to the `default:` `assert`.

I've also added some fallbacks / dummy code so the asserts can be skipped using `-DNDEBUG` in some cases. However, this "feature" is merely a cruel hack and should be used with caution.

(This change also helps with automating the compatibility list as users only have to report the assert location in most cases. A script can automatically fetch the lines in question from GitHub)

---

I've also noticed that the bumpmapping is wrong (according to the GL spec). I'll test and fix this some other time. I've still removed the ugly fall-trough in that code and reordered all texturing modes as they are numbered in hardware.