### PR TITLE
Support blit surface format 0x4

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -2813,6 +2813,9 @@ static void pgraph_method(NV2AState *d,
             case NV062_SET_COLOR_FORMAT_LE_Y8:
                 bytes_per_pixel = 1;
                 break;
+            case NV062_SET_COLOR_FORMAT_LE_R5G6B5:
+                bytes_per_pixel = 2;
+                break;
             case NV062_SET_COLOR_FORMAT_LE_A8R8G8B8:
                 bytes_per_pixel = 4;
                 break;

--- a/hw/xbox/nv2a_int.h
+++ b/hw/xbox/nv2a_int.h
@@ -670,6 +670,7 @@
 #   define NV062_SET_CONTEXT_DMA_IMAGE_DESTIN                 0x00000188
 #   define NV062_SET_COLOR_FORMAT                             0x00000300
 #       define NV062_SET_COLOR_FORMAT_LE_Y8                    0x01
+#       define NV062_SET_COLOR_FORMAT_LE_R5G6B5                0x04
 #       define NV062_SET_COLOR_FORMAT_LE_A8R8G8B8              0x0A
 #   define NV062_SET_PITCH                                    0x00000304
 #   define NV062_SET_OFFSET_SOURCE                            0x00000308


### PR DESCRIPTION
Used in "Just Cause":

![Just Cause, screenshot by JohnGodgames](https://cloud.githubusercontent.com/assets/11453507/26471292/6ea4224a-41a1-11e7-8fee-c2df9c54d4f1.PNG)

Seems to display correctly but crashes with signed color channels then (which is a different issue).