### PR TITLE
Fix: all lights used same shader var since 9fd88f53

### DIFF
--- a/hw/xbox/nv2a.c
+++ b/hw/xbox/nv2a.c
@@ -1921,20 +1921,20 @@ static void pgraph_shader_update_constants(PGRAPHState *pg,
 
         for (i = 0; i < NV2A_MAX_LIGHTS; i++) {
             GLint loc;
-            loc = binding->light_infinite_half_vector_loc;
+            loc = binding->light_infinite_half_vector_loc[i];
             if (loc != -1) {
                 glUniform3fv(loc, 1, pg->light_infinite_half_vector[i]);
             }
-            loc = binding->light_infinite_direction_loc;
+            loc = binding->light_infinite_direction_loc[i];
             if (loc != -1) {
                 glUniform3fv(loc, 1, pg->light_infinite_direction[i]);
             }
 
-            loc = binding->light_local_position_loc;
+            loc = binding->light_local_position_loc[i];
             if (loc != -1) {
                 glUniform3fv(loc, 1, pg->light_local_position[i]);
             }
-            loc = binding->light_local_attenuation_loc;
+            loc = binding->light_local_attenuation_loc[i];
             if (loc != -1) {
                 glUniform3fv(loc, 1, pg->light_local_attenuation[i]);
             }

--- a/hw/xbox/nv2a_shaders.c
+++ b/hw/xbox/nv2a_shaders.c
@@ -930,14 +930,14 @@ ShaderBinding* generate_shaders(const ShaderState state)
     }
     for (i = 0; i < NV2A_MAX_LIGHTS; i++) {
         snprintf(tmp, sizeof(tmp), "lightInfiniteHalfVector%d", i);
-        ret->light_infinite_half_vector_loc = glGetUniformLocation(program, tmp);
+        ret->light_infinite_half_vector_loc[i] = glGetUniformLocation(program, tmp);
         snprintf(tmp, sizeof(tmp), "lightInfiniteDirection%d", i);
-        ret->light_infinite_direction_loc = glGetUniformLocation(program, tmp);
+        ret->light_infinite_direction_loc[i] = glGetUniformLocation(program, tmp);
 
         snprintf(tmp, sizeof(tmp), "lightLocalPosition%d", i);
-        ret->light_local_position_loc = glGetUniformLocation(program, tmp);
+        ret->light_local_position_loc[i] = glGetUniformLocation(program, tmp);
         snprintf(tmp, sizeof(tmp), "lightLocalAttenuation%d", i);
-        ret->light_local_attenuation_loc = glGetUniformLocation(program, tmp);
+        ret->light_local_attenuation_loc[i] = glGetUniformLocation(program, tmp);
     }
 
     return ret;

--- a/hw/xbox/nv2a_shaders.h
+++ b/hw/xbox/nv2a_shaders.h
@@ -103,10 +103,10 @@ typedef struct ShaderBinding {
 
     GLint fog_color_loc;
     GLint fog_param_loc[2];
-    GLint light_infinite_half_vector_loc;
-    GLint light_infinite_direction_loc;
-    GLint light_local_position_loc;
-    GLint light_local_attenuation_loc;
+    GLint light_infinite_half_vector_loc[NV2A_MAX_LIGHTS];
+    GLint light_infinite_direction_loc[NV2A_MAX_LIGHTS];
+    GLint light_local_position_loc[NV2A_MAX_LIGHTS];
+    GLint light_local_attenuation_loc[NV2A_MAX_LIGHTS];
 
 } ShaderBinding;
 


### PR DESCRIPTION
Should fix #88 
Huge thanks to @JohnGodgames for reporting this (and also bisecting it).

I originally thought we might use some wrong register now (bad mapping from the internal registers to our vars), but it turns out that this is an issue with re-using a set of variables in a loop.

---

I'd like to get some @JohnGodgames test results before merge. I'm worried this might still be incomplete in some way.